### PR TITLE
Fix short event text alignment in 15-minute blocks

### DIFF
--- a/components/week/EventBlock.tsx
+++ b/components/week/EventBlock.tsx
@@ -34,6 +34,7 @@ export function EventBlock({
 
     const top = (visibleTopMin - viewStartMin) * pxPerMin
     const height = Math.max((visibleBottomMin - visibleTopMin) * pxPerMin, 18)
+    const isShortBlock = height <= 20
 
     const startTxt = minToHHMM(item.startMin)
     const endTxt = minToHHMM(item.endMin)
@@ -154,9 +155,10 @@ export function EventBlock({
 
     return (
         <div
-            className={`absolute rounded border px-2 py-1 shadow-sm overflow-hidden
+            className={`absolute rounded border px-2 shadow-sm overflow-hidden
             ${selected ? "border-blue-400 bg-blue-200" : "border-blue-200 bg-blue-50 hover:bg-blue-100 hover:shadow-sm"}
             cursor-grab active:cursor-grabbing touch-none`}
+            data-eventblock="1"
             style={{ top, height, ...widthStyle }}
             onPointerDown={onPointerDown}
             title={`${startTxt}–${endTxt}`}
@@ -200,8 +202,12 @@ export function EventBlock({
                 })
 
                 return (
-                    <div className="flex items-start gap-1">
-                        <div className="flex-1 font-medium text-gray-900 truncate text-xs">
+                    <div
+                        className={`flex gap-1 ${isShortBlock ? "h-full items-center py-0.5" : "items-start py-1"}`}
+                    >
+                        <div
+                            className={`flex-1 truncate font-medium text-gray-900 text-xs ${isShortBlock ? "leading-none" : "leading-4"}`}
+                        >
                             {item.label || "（未入力）"}
                         </div>
 

--- a/docs/issue-logs/README.md
+++ b/docs/issue-logs/README.md
@@ -1,0 +1,9 @@
+# Issue Logs
+
+This directory stores short implementation logs for issue fixes.
+
+Each log should capture:
+- the user-visible symptom
+- the likely root cause
+- the chosen fix
+- how the fix was verified

--- a/docs/issue-logs/README.md
+++ b/docs/issue-logs/README.md
@@ -2,8 +2,16 @@
 
 This directory stores short implementation logs for issue fixes.
 
+このディレクトリには、Issue 修正時の短い実装ログを保存します。
+
 Each log should capture:
 - the user-visible symptom
 - the likely root cause
 - the chosen fix
 - how the fix was verified
+
+各ログには、少なくとも次の内容を残します。
+- ユーザーから見た症状
+- 想定される原因
+- 採用した修正方法
+- どのように修正を検証したか

--- a/docs/issue-logs/issue-9-short-event-text-alignment.md
+++ b/docs/issue-logs/issue-9-short-event-text-alignment.md
@@ -32,3 +32,40 @@
 
 - This fix is intentionally scoped to issue #9 only.
 - Related interaction issues around very small blocks, such as resize and link hit areas, should continue to be tracked separately.
+
+---
+
+# Issue #9: 15分イベントのテキスト位置ずれ
+
+- 日付: 2026-04-22
+- Issue: [#9](https://github.com/isikoro1/timebox/issues/9)
+- PR: [#11](https://github.com/isikoro1/timebox/pull/11)
+
+## 症状
+
+- イベントブロックを最小の 15 分サイズまで縮めると、ラベルが想定より下に見える。
+- 通常サイズのイベントに比べて、短いブロックの視認性が下がる。
+
+## 原因
+
+- `EventBlock` が、ブロックの高さに関係なく同じ縦方向パディングと上寄せレイアウトを使っていた。
+- 最小高さでは、上下の固定 UI と `py-1` によって、テキスト領域として使える縦方向スペースが足りなくなっていた。
+- さらにコンテンツ行が `items-start` のままだったため、ラベルが短いブロック内で見た目上センターに来ず、下寄りに見えていた。
+
+## 修正方法
+
+- `components/week/EventBlock.tsx` で、描画後の高さが短いイベントブロックを判定するようにした。
+- 短いブロックだけ、利用可能な高さいっぱいを使うコンパクトレイアウトに切り替え、コンテンツを縦中央揃えにした。
+- 短いブロックではラベルの line-height を詰めて、テキストが下に押し出されないようにした。
+- 通常サイズのブロックは従来の上寄せレイアウトのままにして、既存表示への影響を避けた。
+- 併せて、ブロック root に `data-eventblock="1"` を付けて、グリッド側の選択解除ロジックがイベントクリックを安定して判別できるようにした。
+
+## 検証
+
+- `cmd /c npm run lint`
+- `cmd /c npm run build`
+
+## 補足
+
+- 今回の修正範囲は issue #9 に限定している。
+- 短いイベントに関連する別の操作系課題、たとえばリサイズやリンクのクリック領域は、別 issue として引き続き扱う。

--- a/docs/issue-logs/issue-9-short-event-text-alignment.md
+++ b/docs/issue-logs/issue-9-short-event-text-alignment.md
@@ -1,0 +1,34 @@
+# Issue #9: Short Event Text Alignment
+
+- Date: 2026-04-22
+- Issue: [#9](https://github.com/isikoro1/timebox/issues/9)
+- PR: [#11](https://github.com/isikoro1/timebox/pull/11)
+
+## Symptom
+
+- When an event block is resized to the minimum 15-minute height, the label appears visually lower than expected.
+- The short block looks harder to scan than taller event blocks.
+
+## Cause
+
+- `EventBlock` used the same vertical padding and top-aligned content layout for every block height.
+- At the minimum rendered height, the fixed top/bottom chrome plus `py-1` left too little space for the text area.
+- Because the content row stayed `items-start`, the label sat near the top edge of the remaining content box instead of appearing optically centered inside the small event block.
+
+## Fix
+
+- Detect very short rendered event blocks in `components/week/EventBlock.tsx`.
+- Switch those blocks to a compact layout that uses the full available height and vertically centers the content row.
+- Reduce the short-block text line height so the label fits cleanly without pushing downward.
+- Keep taller blocks on the existing top-aligned layout to avoid regressions in the normal case.
+- Add `data-eventblock="1"` to the block root so the grid's deselect logic can keep recognizing event clicks consistently.
+
+## Verification
+
+- `cmd /c npm run lint`
+- `cmd /c npm run build`
+
+## Notes
+
+- This fix is intentionally scoped to issue #9 only.
+- Related interaction issues around very small blocks, such as resize and link hit areas, should continue to be tracked separately.


### PR DESCRIPTION
## Summary
- center content vertically for very short event blocks
- keep the regular top-aligned layout for taller blocks
- add an issue log under `docs/issue-logs/issue-9-short-event-text-alignment.md`
- tag event blocks with `data-eventblock` so background clicks still ignore them consistently

## Root Cause
- the block used the same padding and top-aligned content layout regardless of rendered height
- on the minimum-height block, that layout left too little usable vertical space and made the label appear lower than expected

## Fix
- detect very short rendered blocks in `EventBlock`
- switch those blocks to a compact `h-full` layout with vertical centering
- tighten line height for the short-block label while leaving normal blocks unchanged

## Verification
- `cmd /c npm run lint`
- `cmd /c npm run build`

## Log
- `docs/issue-logs/issue-9-short-event-text-alignment.md`

Closes #9