### PR TITLE
Fix initial current time line hydration mismatch

### DIFF
--- a/components/WeekGrid.tsx
+++ b/components/WeekGrid.tsx
@@ -94,7 +94,7 @@ export function WeekGrid({
     pxPerMin: number
     gridMin: number
     defaultDurationMin: number
-    nowMin: number
+    nowMin: number | null
     viewStartMin: number
     viewEndMin: number
     visibleDays: number[]

--- a/components/week/DayColumn.tsx
+++ b/components/week/DayColumn.tsx
@@ -32,7 +32,7 @@ export function DayColumn({
     pxPerMin: number
     gridMin: number
     defaultDurationMin: number
-    nowMin: number
+    nowMin: number | null
     viewStartMin: number
     viewEndMin: number
     heightPx: number
@@ -71,7 +71,7 @@ export function DayColumn({
                 )
             })}
 
-            {nowMin >= viewStartMin && nowMin <= viewEndMin && (
+            {nowMin !== null && nowMin >= viewStartMin && nowMin <= viewEndMin && (
                 <div
                     className="absolute left-0 right-0 border-t-2 border-red-500"
                     style={{ top: (nowMin - viewStartMin) * pxPerMin }}

--- a/docs/issue-logs/README.md
+++ b/docs/issue-logs/README.md
@@ -1,0 +1,17 @@
+# Issue Logs
+
+This directory stores short implementation logs for issue fixes.
+
+このディレクトリには、Issue 修正時の短い実装ログを保存します。
+
+Each log should capture:
+- the user-visible symptom
+- the likely root cause
+- the chosen fix
+- how the fix was verified
+
+各ログには、少なくとも次の内容を残します。
+- ユーザーから見た症状
+- 想定される原因
+- 採用した修正方法
+- どのように修正を検証したか

--- a/docs/issue-logs/issue-6-initial-now-line-hydration.md
+++ b/docs/issue-logs/issue-6-initial-now-line-hydration.md
@@ -1,0 +1,65 @@
+# Issue #6: Initial Current Time Line Hydration
+
+- Date: 2026-04-22
+- Issue: [#6](https://github.com/isikoro1/timebox/issues/6)
+
+## Symptom
+
+- On initial load, the current time line can appear at the wrong position.
+- After the client updates time state, the red line moves to the correct position.
+
+## Cause
+
+- The current time value was computed during the initial render.
+- In a statically rendered Next.js page, that initial render can happen in an environment with a different clock or timezone than the browser.
+- As a result, the first painted line could reflect server-side time while later updates reflect client-side local time.
+
+## Fix
+
+- Initialize `useNowMin` with `null` instead of computing time during the first render.
+- After mount, compute the browser-local time inside `useEffect` and keep updating it on the existing interval.
+- Render the current time line only when the client-side time is available.
+
+## Verification
+
+- `cmd /c npm run lint`
+- `cmd /c npm run build`
+
+## Notes
+
+- This fix is intentionally scoped to issue #6 only.
+- It prefers a correct first client render over showing a potentially incorrect pre-hydration line.
+
+---
+
+# Issue #6: 初回表示時の現在時刻ラインと hydration
+
+- 日付: 2026-04-22
+- Issue: [#6](https://github.com/isikoro1/timebox/issues/6)
+
+## 症状
+
+- 初回読み込み時に、現在時刻ラインが誤った位置に表示されることがある。
+- その後クライアント側で時刻状態が更新されると、赤いラインは正しい位置に戻る。
+
+## 原因
+
+- 現在時刻の値を初回レンダー中に計算していた。
+- 静的生成された Next.js ページでは、その初回レンダーがブラウザとは異なる時計やタイムゾーンの環境で行われることがある。
+- そのため、最初に描画されたラインだけサーバー側の時刻を反映し、以後の更新ではブラウザのローカル時刻を反映する、という不一致が起きていた可能性が高い。
+
+## 修正方法
+
+- `useNowMin` の初期値を、初回レンダーで時刻を計算する形ではなく `null` に変更した。
+- マウント後に `useEffect` の中でブラウザのローカル時刻を計算し、既存の interval で更新を継続するようにした。
+- クライアント側の時刻が利用可能になるまで、現在時刻ライン自体を描画しないようにした。
+
+## 検証
+
+- `cmd /c npm run lint`
+- `cmd /c npm run build`
+
+## 補足
+
+- 今回の修正範囲は issue #6 に限定している。
+- 誤った初期ラインを一瞬でも見せるより、クライアント時刻が確定してから正しいラインを表示する方を優先している。

--- a/hooks/useNowMin.ts
+++ b/hooks/useNowMin.ts
@@ -3,10 +3,7 @@
 import { useEffect, useState } from "react"
 
 export function useNowMin(intervalMs: number = 15000) {
-    const [nowMin, setNowMin] = useState<number>(() => {
-        const d = new Date()
-        return d.getHours() * 60 + d.getMinutes()
-    })
+    const [nowMin, setNowMin] = useState<number | null>(null)
 
     useEffect(() => {
         const tick = () => {


### PR DESCRIPTION
## Summary
- avoid computing the current time during the first render
- render the current time line only after client-local time is available
- add a bilingual issue log under `docs/issue-logs/issue-6-initial-now-line-hydration.md`

## Root Cause
- the initial current-time value was computed during render
- on a statically rendered page, that first render can use a different clock or timezone than the browser
- that let the first painted red line reflect server-side time before the client corrected it

## Fix
- initialize `useNowMin` with `null`
- set browser-local time after mount inside `useEffect`
- only render the current time line once client time exists

## Verification
- `cmd /c npm run lint`
- `cmd /c npm run build`

## Log
- `docs/issue-logs/issue-6-initial-now-line-hydration.md`

Closes #6