### PR TITLE
Add timeline zoom gestures and holiday styling / タイムラインのズーム操作と休日表示を追加

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,15 @@ import { useAlarm } from "../hooks/useAlarm"
 import { useNowMin } from "../hooks/useNowMin"
 import { useSelection } from "../hooks/useSelection"
 import { useTimeboxingItems } from "../hooks/useTimeboxingItems"
-import { MAX_ZOOM, MIN_ZOOM, ZOOM_STEP, useViewOptions } from "../hooks/useViewOptions"
+import {
+    DAY_WIDTH_ZOOM_STEP,
+    MAX_DAY_WIDTH_ZOOM,
+    MAX_ZOOM,
+    MIN_DAY_WIDTH_ZOOM,
+    MIN_ZOOM,
+    ZOOM_STEP,
+    useViewOptions,
+} from "../hooks/useViewOptions"
 import { formatDateHeader, getTodayDateKey, parseDateKey, toDateKey } from "../lib/date"
 import { formatJapaneseEraYear } from "../lib/japaneseCalendar"
 import { parseEventItems } from "../lib/storage"
@@ -25,13 +33,26 @@ const SWIPE_MAX_TAP_MS = 700
 const SWIPE_VERTICAL_CANCEL_Y = 32
 const SWIPE_HORIZONTAL_RATIO = 1.4
 const SWIPE_EXCLUDED_TARGETS = 'button, input, textarea, select, a, [data-eventblock="1"]'
+const PINCH_MIN_DISTANCE = 40
 
 type SwipeStart = {
     pointerId: number
+    pointerType: string
     x: number
     y: number
     time: number
     cancelled: boolean
+}
+
+type TouchPoint = {
+    x: number
+    y: number
+}
+
+type PinchStart = {
+    distance: number
+    zoom: number
+    dayWidthZoom: number
 }
 
 function buildExportFilename() {
@@ -83,6 +104,19 @@ function getMonthCalendarDays(monthDateKey: string) {
     })
 }
 
+function clamp(value: number, min: number, max: number) {
+    return Math.min(max, Math.max(min, value))
+}
+
+function snapToStep(value: number, step: number) {
+    return Math.round(value / step) * step
+}
+
+function getPinchDistance(points: TouchPoint[]) {
+    if (points.length < 2) return 0
+    return Math.hypot(points[0].x - points[1].x, points[0].y - points[1].y)
+}
+
 export default function Home() {
     const { items, setItems, loaded } = useTimeboxingItems(STORAGE_KEY)
     const nowMin = useNowMin(15000)
@@ -97,10 +131,11 @@ export default function Home() {
     const {
         startHour,
         setStartHour,
-        visibleDayCount,
-        setVisibleDayCount,
         zoom,
         setZoom,
+        dayWidthZoom,
+        setDayWidthZoom,
+        dayColumnMinWidth,
         centerDateKey,
         setCenterDateKey,
         shiftCenter,
@@ -115,6 +150,8 @@ export default function Home() {
     const clipboardRef = useRef<EventItem | null>(null)
     const importInputRef = useRef<HTMLInputElement | null>(null)
     const swipeStartRef = useRef<SwipeStart | null>(null)
+    const activeTouchPointsRef = useRef<Map<number, TouchPoint>>(new Map())
+    const pinchStartRef = useRef<PinchStart | null>(null)
 
     const alarmItems = useMemo(
         () =>
@@ -276,20 +313,63 @@ export default function Home() {
     const todayKey = getTodayDateKey()
     const calendarDays = getMonthCalendarDays(calendarMonthKey)
     const moveDate = (direction: -1 | 1) => shiftCenter(direction)
+    const zoomTimeline = (direction: -1 | 1) => setZoom((current) => current + direction * ZOOM_STEP)
+    const zoomDayWidth = (direction: -1 | 1) =>
+        setDayWidthZoom((current) => current + direction * DAY_WIDTH_ZOOM_STEP)
     const jumpToDate = (dateKey: string) => {
         setCenterDateKey(dateKey)
         setCalendarMonthKey(dateKey)
         setCalendarOpen(false)
     }
     const jumpToToday = () => jumpToDate(todayKey)
+    const beginPinch = () => {
+        const distance = getPinchDistance([...activeTouchPointsRef.current.values()])
+        if (distance < PINCH_MIN_DISTANCE) return
+
+        pinchStartRef.current = {
+            distance,
+            zoom,
+            dayWidthZoom,
+        }
+    }
+    const updatePinch = () => {
+        const pinchStart = pinchStartRef.current
+        if (!pinchStart) return
+
+        const distance = getPinchDistance([...activeTouchPointsRef.current.values()])
+        if (distance < PINCH_MIN_DISTANCE) return
+
+        const scale = distance / pinchStart.distance
+        const nextZoom = clamp(snapToStep(pinchStart.zoom * scale, ZOOM_STEP), MIN_ZOOM, MAX_ZOOM)
+        const nextDayWidthZoom = clamp(
+            snapToStep(pinchStart.dayWidthZoom * scale, DAY_WIDTH_ZOOM_STEP),
+            MIN_DAY_WIDTH_ZOOM,
+            MAX_DAY_WIDTH_ZOOM
+        )
+
+        setZoom(nextZoom)
+        setDayWidthZoom(nextDayWidthZoom)
+    }
     const startSwipe = (event: ReactPointerEvent<HTMLDivElement>) => {
-        if (event.pointerType !== "touch" || !event.isPrimary) return
+        if (event.pointerType === "touch") {
+            activeTouchPointsRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY })
+            if (activeTouchPointsRef.current.size >= 2) {
+                swipeStartRef.current = null
+                beginPinch()
+                return
+            }
+        }
+
+        if (event.pointerType === "mouse" && event.button !== 0) return
+        if (event.pointerType !== "touch" && event.pointerType !== "mouse") return
 
         const target = event.target as HTMLElement | null
         if (target?.closest(SWIPE_EXCLUDED_TARGETS)) return
 
+        event.currentTarget.setPointerCapture(event.pointerId)
         swipeStartRef.current = {
             pointerId: event.pointerId,
+            pointerType: event.pointerType,
             x: event.clientX,
             y: event.clientY,
             time: performance.now(),
@@ -297,8 +377,17 @@ export default function Home() {
         }
     }
     const trackSwipe = (event: ReactPointerEvent<HTMLDivElement>) => {
+        if (event.pointerType === "touch" && activeTouchPointsRef.current.has(event.pointerId)) {
+            activeTouchPointsRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY })
+            if (pinchStartRef.current) {
+                updatePinch()
+                return
+            }
+        }
+
         const start = swipeStartRef.current
-        if (!start || event.pointerId !== start.pointerId || event.pointerType !== "touch") return
+        if (!start || event.pointerId !== start.pointerId || event.pointerType !== start.pointerType) return
+        if (event.pointerType === "mouse" && event.buttons !== 1) return
 
         const dx = event.clientX - start.x
         const dy = event.clientY - start.y
@@ -307,9 +396,18 @@ export default function Home() {
         if (verticalIntent) start.cancelled = true
     }
     const finishSwipe = (event: ReactPointerEvent<HTMLDivElement>) => {
+        if (event.pointerType === "touch") {
+            activeTouchPointsRef.current.delete(event.pointerId)
+            if (pinchStartRef.current) {
+                if (activeTouchPointsRef.current.size < 2) pinchStartRef.current = null
+                swipeStartRef.current = null
+                return
+            }
+        }
+
         const start = swipeStartRef.current
         swipeStartRef.current = null
-        if (!start || start.cancelled || event.pointerId !== start.pointerId || event.pointerType !== "touch") return
+        if (!start || start.cancelled || event.pointerId !== start.pointerId || event.pointerType !== start.pointerType) return
 
         const dx = event.clientX - start.x
         const dy = event.clientY - start.y
@@ -388,24 +486,46 @@ export default function Home() {
                 </svg>
             </button>
             <div className="fixed right-16 top-3 z-40 flex h-11 items-center gap-1 rounded-full border border-gray-200 bg-white/95 p-1 text-gray-700 shadow-lg shadow-gray-900/10 backdrop-blur sm:right-[4.25rem] sm:top-4">
-                <button
-                    className="flex h-9 w-9 items-center justify-center rounded-full text-base font-semibold transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
-                    type="button"
-                    aria-label="Show fewer days"
-                    disabled={visibleDayCount <= 1}
-                    onClick={() => setVisibleDayCount((current) => current - 1)}
-                >
-                    -
-                </button>
-                <span className="w-6 text-center text-sm font-semibold tabular-nums" aria-label="Visible days">
-                    {visibleDayCount}
+                <span className="pl-2 text-xs font-semibold text-gray-500" aria-hidden="true">
+                    H
                 </span>
                 <button
                     className="flex h-9 w-9 items-center justify-center rounded-full text-base font-semibold transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
                     type="button"
-                    aria-label="Show more days"
-                    disabled={visibleDayCount >= 31}
-                    onClick={() => setVisibleDayCount((current) => current + 1)}
+                    aria-label="Compress day width"
+                    disabled={dayWidthZoom <= MIN_DAY_WIDTH_ZOOM}
+                    onClick={() => zoomDayWidth(-1)}
+                >
+                    -
+                </button>
+                <button
+                    className="flex h-9 w-9 items-center justify-center rounded-full text-base font-semibold transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+                    type="button"
+                    aria-label="Expand day width"
+                    disabled={dayWidthZoom >= MAX_DAY_WIDTH_ZOOM}
+                    onClick={() => zoomDayWidth(1)}
+                >
+                    +
+                </button>
+                <div className="mx-0.5 h-6 w-px bg-gray-200" aria-hidden="true" />
+                <span className="text-xs font-semibold text-gray-500" aria-hidden="true">
+                    V
+                </span>
+                <button
+                    className="flex h-9 w-9 items-center justify-center rounded-full text-base font-semibold transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+                    type="button"
+                    aria-label="Compress timeline height"
+                    disabled={zoom <= MIN_ZOOM}
+                    onClick={() => zoomTimeline(-1)}
+                >
+                    -
+                </button>
+                <button
+                    className="flex h-9 w-9 items-center justify-center rounded-full text-base font-semibold transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+                    type="button"
+                    aria-label="Expand timeline height"
+                    disabled={zoom >= MAX_ZOOM}
+                    onClick={() => zoomTimeline(1)}
                 >
                     +
                 </button>
@@ -556,7 +676,9 @@ export default function Home() {
                     onPointerDown={startSwipe}
                     onPointerMove={trackSwipe}
                     onPointerUp={finishSwipe}
-                    onPointerCancel={() => {
+                    onPointerCancel={(event) => {
+                        activeTouchPointsRef.current.delete(event.pointerId)
+                        if (activeTouchPointsRef.current.size < 2) pinchStartRef.current = null
                         swipeStartRef.current = null
                     }}
                 >
@@ -568,6 +690,7 @@ export default function Home() {
                         pxPerMin={pxPerMin}
                         viewStartMin={viewStartMin}
                         viewEndMin={viewEndMin}
+                        dayColumnMinWidth={dayColumnMinWidth}
                         nowMin={nowMin}
                         onAddQuick={onAddQuick}
                         onMoveEvent={(id, next) => {
@@ -637,21 +760,6 @@ export default function Home() {
                             <section className={SETTINGS_SECTION_CLASS}>
                                 <h3 className="text-sm font-semibold text-gray-900">Timeline</h3>
                                 <label className="block text-sm text-gray-700">
-                                    <div className="mb-2 flex items-center justify-between gap-3">
-                                        <span>Scale</span>
-                                        <span className="font-semibold tabular-nums text-gray-900">{zoom}%</span>
-                                    </div>
-                                    <input
-                                        className="w-full accent-blue-600"
-                                        type="range"
-                                        min={MIN_ZOOM}
-                                        max={MAX_ZOOM}
-                                        step={ZOOM_STEP}
-                                        value={zoom}
-                                        onChange={(event) => setZoom(Number(event.target.value))}
-                                    />
-                                </label>
-                                <label className="mt-4 block text-sm text-gray-700">
                                     <div className="mb-2">Start hour</div>
                                     <select
                                         className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900"

--- a/components/WeekGrid.tsx
+++ b/components/WeekGrid.tsx
@@ -2,7 +2,7 @@
 
 import React from "react"
 import { DayColumn } from "./week/DayColumn"
-import { formatDateHeader, getTodayDateKey } from "../lib/date"
+import { formatDateHeader, getTodayDateKey, parseDateKey } from "../lib/date"
 import { getJapaneseHolidayName } from "../lib/japaneseCalendar"
 import { minToHHMM } from "../lib/time"
 
@@ -19,6 +19,21 @@ export type EventItem = {
 const TIME_COLUMN_WIDTH = 56
 
 type LayoutInfo = { lane: 0 | 1; lanesCount: 1 | 2 }
+type DayTone = "weekday" | "saturday" | "rest"
+
+function getDayTone(dateKey: string, holidayName: string | null): DayTone {
+    const day = parseDateKey(dateKey).getDay()
+    if (holidayName || day === 0) return "rest"
+    if (day === 6) return "saturday"
+    return "weekday"
+}
+
+function getHeaderClass(isToday: boolean, dayTone: DayTone) {
+    if (isToday) return "bg-red-50 text-red-700 ring-1 ring-inset ring-red-200"
+    if (dayTone === "rest") return "bg-rose-50 text-rose-700 ring-1 ring-inset ring-rose-100"
+    if (dayTone === "saturday") return "bg-sky-50 text-sky-700 ring-1 ring-inset ring-sky-100"
+    return "text-gray-800"
+}
 
 function computeTwoLaneLayout(items: EventItem[]): Map<string, LayoutInfo> {
     const sorted = [...items].sort((a, b) => a.startMin - b.startMin || a.endMin - b.endMin)
@@ -75,6 +90,7 @@ export function WeekGrid({
     viewStartMin,
     viewEndMin,
     visibleDateKeys,
+    dayColumnMinWidth,
     selectedId,
     onAddQuick,
     onDoubleClickEmpty,
@@ -90,6 +106,7 @@ export function WeekGrid({
     viewStartMin: number
     viewEndMin: number
     visibleDateKeys: string[]
+    dayColumnMinWidth: number
     selectedId: string | null
     onAddQuick?: (dateKey: string, startMin: number, endMin: number) => void
     onDoubleClickEmpty?: (dateKey: string, startMin: number, endMin: number) => void
@@ -116,9 +133,9 @@ export function WeekGrid({
 
     const startHour = Math.floor(viewStartMin / 60)
     const endHour = Math.floor(viewEndMin / 60)
-    const dayColumnMin = visibleDateKeys.length > 7 ? 112 : 0
-    const dayColumnTemplate = `repeat(${visibleDateKeys.length}, minmax(${dayColumnMin}px, 1fr))`
+    const dayColumnTemplate = `repeat(${visibleDateKeys.length}, minmax(${dayColumnMinWidth}px, 1fr))`
     const headerColumns = `${TIME_COLUMN_WIDTH}px ${dayColumnTemplate}`
+    const contentMinWidth = TIME_COLUMN_WIDTH + dayColumnMinWidth * visibleDateKeys.length
     const handleEmpty = onAddQuick ?? onDoubleClickEmpty ?? (() => {})
     const todayKey = getTodayDateKey()
     const todayIndex = visibleDateKeys.indexOf(todayKey)
@@ -135,7 +152,7 @@ export function WeekGrid({
                 onDeselect()
             }}
         >
-            <div className="min-w-full">
+            <div className="min-w-full" style={{ minWidth: contentMinWidth }}>
                 <div
                     className="sticky top-0 z-30 grid border-b border-gray-200 bg-gray-50/95 backdrop-blur"
                     style={{ gridTemplateColumns: headerColumns }}
@@ -145,12 +162,14 @@ export function WeekGrid({
                         const isToday = dateKey === todayKey
                         const [dayName, dateLabel] = formatDateHeader(dateKey).split(" ")
                         const holidayName = getJapaneseHolidayName(dateKey)
+                        const dayTone = getDayTone(dateKey, holidayName)
                         return (
                             <div
                                 key={dateKey}
-                                className={`min-w-0 border-r border-gray-200 px-1 py-1.5 text-center text-xs font-semibold last:border-r-0 ${
-                                    isToday ? "bg-red-50 text-red-700 ring-1 ring-inset ring-red-200" : "text-gray-800"
-                                }`}
+                                className={`min-w-0 border-r border-gray-200 px-1 py-1.5 text-center text-xs font-semibold last:border-r-0 ${getHeaderClass(
+                                    isToday,
+                                    dayTone
+                                )}`}
                             >
                                 <div className="truncate leading-4">{dayName}</div>
                                 <div className="truncate leading-4">{dateLabel}</div>
@@ -205,6 +224,7 @@ export function WeekGrid({
                                 viewEndMin={viewEndMin}
                                 heightPx={gridHeightPx}
                                 isToday={dateKey === todayKey}
+                                dayTone={getDayTone(dateKey, getJapaneseHolidayName(dateKey))}
                                 selectedId={selectedId}
                                 onDoubleClickEmpty={handleEmpty}
                                 onMoveEvent={onMoveEvent}
@@ -214,7 +234,7 @@ export function WeekGrid({
 
                         {showNowLine ? (
                             <div
-                                className="pointer-events-none absolute left-0 right-0 z-40 border-t-2 border-gray-700/65"
+                                className="pointer-events-none absolute left-0 right-0 z-10 border-t-2 border-gray-700/65"
                                 style={{ top: nowLineTop }}
                                 title={`now ${minToHHMM(nowMin)}`}
                                 aria-hidden="true"

--- a/components/week/DayColumn.tsx
+++ b/components/week/DayColumn.tsx
@@ -6,6 +6,15 @@ import type { EventItem } from "@/components/WeekGrid"
 import type { LayoutInfo } from "./layout"
 import { EventBlock } from "./EventBlock"
 
+type DayTone = "weekday" | "saturday" | "rest"
+
+function getColumnClass(isToday: boolean, dayTone: DayTone) {
+    if (isToday) return "bg-red-50/40 shadow-[inset_0_0_0_1px_rgba(248,113,113,0.35)]"
+    if (dayTone === "rest") return "bg-rose-50/30"
+    if (dayTone === "saturday") return "bg-sky-50/25"
+    return ""
+}
+
 export function DayColumn({
     dateKey,
     visibleIndex,
@@ -19,6 +28,7 @@ export function DayColumn({
     viewEndMin,
     heightPx,
     isToday,
+    dayTone,
     selectedId,
     onDoubleClickEmpty,
     onMoveEvent,
@@ -36,6 +46,7 @@ export function DayColumn({
     viewEndMin: number
     heightPx: number
     isToday: boolean
+    dayTone: DayTone
     selectedId: string | null
     onDoubleClickEmpty: (dateKey: string, startMin: number, endMin: number) => void
     onMoveEvent: (id: string, next: { dateKey: string; startMin: number; endMin: number }) => void
@@ -46,9 +57,7 @@ export function DayColumn({
 
     return (
         <div
-            className={`relative border-r last:border-r-0 select-none ${
-                isToday ? "bg-red-50/40 shadow-[inset_0_0_0_1px_rgba(248,113,113,0.35)]" : ""
-            }`}
+            className={`relative border-r last:border-r-0 select-none ${getColumnClass(isToday, dayTone)}`}
             data-daycol="1"
             data-visible-index={visibleIndex}
             style={{ height: heightPx }}

--- a/docs/issue-logs/issue-27-mobile-swipe-navigation.md
+++ b/docs/issue-logs/issue-27-mobile-swipe-navigation.md
@@ -11,11 +11,15 @@ Date navigation was only available through fixed buttons, and touch gestures on 
 ## Fix
 
 - Added touch-only pointer gesture tracking around the timeline.
-- Moved to the previous or next date when a quick horizontal swipe starts on timeline empty space.
+- Moved to the previous or next date when a quick horizontal swipe or mouse drag starts on timeline empty space.
 - Cancelled swipe navigation once vertical movement clearly indicates timeline scrolling.
 - Ignored swipe starts from buttons, inputs, links, selects, textareas, and event blocks.
 - Hid the bottom previous/next buttons on mobile and kept them available from the `sm` breakpoint upward.
-- Kept visible-day controls outside the sticky timeline header so they do not interfere with the scrollable grid.
+- Replaced visible-day count controls with top-row horizontal and vertical zoom buttons.
+- Rendered a fixed 31-day range so users can scroll horizontally to nearby dates.
+- Added two-finger pinch zoom on the timeline to scale both day width and timeline height together.
+- Highlighted Saturdays, Sundays, and Japanese holidays in the header and day columns.
+- Lowered the current-time line layer so it no longer overlaps the sticky date header text.
 
 ## Verification
 
@@ -23,4 +27,6 @@ Date navigation was only available through fixed buttons, and touch gestures on 
 - `npm run lint`
 - `npm run build`
 - In-app browser: confirmed the timeline still renders cleanly after the navigation control changes.
-- Code path check: confirmed swipe navigation is touch-only, ignores interactive targets, cancels on vertical movement, and leaves event-block pointer handlers untouched.
+- In-app browser: confirmed mouse dragging timeline empty space moves the date range.
+- In-app browser: confirmed weekend and holiday columns are visually distinct and the current-time line stays below the sticky header.
+- Code path check: confirmed swipe navigation ignores interactive targets, cancels on vertical movement, supports mouse and touch pointers, and leaves event-block pointer handlers untouched.

--- a/hooks/useViewOptions.ts
+++ b/hooks/useViewOptions.ts
@@ -3,49 +3,58 @@
 import { useMemo, useState } from "react"
 import { addDays, getTodayDateKey } from "../lib/date"
 
-export const MIN_VISIBLE_DAY_COUNT = 1
-export const MAX_VISIBLE_DAY_COUNT = 31
+const VISIBLE_DAY_COUNT = 31
 export const MIN_ZOOM = 75
 export const MAX_ZOOM = 200
 export const ZOOM_STEP = 5
+export const MIN_DAY_WIDTH_ZOOM = 70
+export const MAX_DAY_WIDTH_ZOOM = 180
+export const DAY_WIDTH_ZOOM_STEP = 10
+const BASE_DAY_COLUMN_WIDTH = 112
 
 export function useViewOptions() {
     const [startHour, setStartHour] = useState(6)
-    const [visibleDayCount, setVisibleDayCount] = useState(7)
     const [zoom, setZoom] = useState(100)
+    const [dayWidthZoom, setDayWidthZoom] = useState(100)
     const [centerDateKey, setCenterDateKey] = useState<string>(getTodayDateKey)
 
     const pxPerMin = 0.96 * (zoom / 100)
+    const dayColumnMinWidth = Math.round(BASE_DAY_COLUMN_WIDTH * (dayWidthZoom / 100))
     const viewStartMin = startHour * 60
     const viewEndMin = 24 * 60
 
     const visibleDateKeys = useMemo(() => {
-        return Array.from({ length: visibleDayCount }, (_, index) => addDays(centerDateKey, index))
-    }, [centerDateKey, visibleDayCount])
+        return Array.from({ length: VISIBLE_DAY_COUNT }, (_, index) => addDays(centerDateKey, index))
+    }, [centerDateKey])
 
     const shiftCenter = (delta: number) => {
         setCenterDateKey((current) => addDays(current, delta))
     }
 
-    const goToday = () => setCenterDateKey(getTodayDateKey())
-    const updateVisibleDayCount = (next: number | ((current: number) => number)) => {
-        setVisibleDayCount((current) => {
+    const updateZoom = (next: number | ((current: number) => number)) => {
+        setZoom((current) => {
             const value = typeof next === "function" ? next(current) : next
-            return Math.min(MAX_VISIBLE_DAY_COUNT, Math.max(MIN_VISIBLE_DAY_COUNT, value))
+            return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value))
+        })
+    }
+    const updateDayWidthZoom = (next: number | ((current: number) => number)) => {
+        setDayWidthZoom((current) => {
+            const value = typeof next === "function" ? next(current) : next
+            return Math.min(MAX_DAY_WIDTH_ZOOM, Math.max(MIN_DAY_WIDTH_ZOOM, value))
         })
     }
 
     return {
         startHour,
         setStartHour,
-        visibleDayCount,
-        setVisibleDayCount: updateVisibleDayCount,
         zoom,
-        setZoom,
+        setZoom: updateZoom,
+        dayWidthZoom,
+        setDayWidthZoom: updateDayWidthZoom,
+        dayColumnMinWidth,
         centerDateKey,
         setCenterDateKey,
         shiftCenter,
-        goToday,
         pxPerMin,
         viewStartMin,
         viewEndMin,


### PR DESCRIPTION
## Summary
- replace visible-day count controls with top-row horizontal and vertical zoom buttons
- render a fixed 31-day timeline range for easier horizontal date scrolling
- add mouse-drag date navigation on empty timeline space
- add two-finger pinch zoom for timeline height and day width
- highlight Saturdays, Sundays, and Japanese holidays in headers and day columns
- fix the current-time line layer so it no longer overlaps sticky header labels
- restore empty-slot schedule creation on double-click after the drag gesture changes
- keep the issue #27 implementation log updated

## Verification
- npx tsc --noEmit
- npm run lint
- npm run build
- in-app browser render check on http://localhost:3001
- in-app browser mouse-drag check for date navigation
- in-app browser visual check for weekend/holiday styling and current-time line layering
- in-app browser double-click check confirmed the Quick Add modal opens with the Label field active

## 概要
- 表示日数の増減コントロールをやめ、上段に横幅と縦幅のズームボタンを追加しました
- 31日分を固定で描画し、横スクロールで近い日付へ移動しやすくしました
- タイムラインの空き領域をマウスで横ドラッグしても、スワイプと同じ日付移動ができるようにしました
- スマホの2本指ピンチで、タイムラインの縦幅と日付列の横幅を同時に拡大縮小できるようにしました
- 土曜、日曜、祝日をヘッダーと列背景で分かるように表示しました
- 現在時刻ラインのレイヤーを下げ、stickyヘッダーの休日名や Today 表示に被らないようにしました
- ドラッグ操作追加後に壊れていた、空き枠ダブルクリックでの予定新規作成を復旧しました
- Issue #27 の実装ログを更新しました

## 検証
- npx tsc --noEmit
- npm run lint
- npm run build
- in-app browser で http://localhost:3001 の描画を確認
- in-app browser でマウス横ドラッグによる日付移動を確認
- in-app browser で土日祝日の表示と現在時刻ラインの重なり解消を確認
- in-app browser で空き枠をダブルクリックし、Quick Add が開いて Label 入力欄が active になることを確認

Refs #27
