### PR TITLE
Restore double-click schedule creation / ダブルクリックでの予定新規作成を復旧

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -366,7 +366,6 @@ export default function Home() {
         const target = event.target as HTMLElement | null
         if (target?.closest(SWIPE_EXCLUDED_TARGETS)) return
 
-        event.currentTarget.setPointerCapture(event.pointerId)
         swipeStartRef.current = {
             pointerId: event.pointerId,
             pointerType: event.pointerType,

--- a/components/week/DayColumn.tsx
+++ b/components/week/DayColumn.tsx
@@ -15,6 +15,10 @@ function getColumnClass(isToday: boolean, dayTone: DayTone) {
     return ""
 }
 
+function shouldIgnoreEmptyAction(target: EventTarget | null) {
+    return target instanceof HTMLElement && Boolean(target.closest('[data-eventblock="1"], button, input, textarea, select, a'))
+}
+
 export function DayColumn({
     dateKey,
     visibleIndex,
@@ -54,6 +58,14 @@ export function DayColumn({
 }) {
     const startHour = Math.floor(viewStartMin / 60)
     const endHour = Math.floor(viewEndMin / 60)
+    const addEventAtClientY = (element: HTMLDivElement, clientY: number) => {
+        const rect = element.getBoundingClientRect()
+        const y = clientY - rect.top
+        const rawMin = viewStartMin + y / pxPerMin
+        const startMin = clamp(snap(rawMin, gridMin), 0, 1440 - defaultDurationMin)
+        const endMin = startMin + defaultDurationMin
+        onDoubleClickEmpty(dateKey, startMin, endMin)
+    }
 
     return (
         <div
@@ -62,12 +74,12 @@ export function DayColumn({
             data-visible-index={visibleIndex}
             style={{ height: heightPx }}
             onDoubleClick={(e) => {
-                const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect()
-                const y = e.clientY - rect.top
-                const rawMin = viewStartMin + y / pxPerMin
-                const startMin = clamp(snap(rawMin, gridMin), 0, 1440 - defaultDurationMin)
-                const endMin = startMin + defaultDurationMin
-                onDoubleClickEmpty(dateKey, startMin, endMin)
+                if (shouldIgnoreEmptyAction(e.target)) return
+                addEventAtClientY(e.currentTarget, e.clientY)
+            }}
+            onClick={(e) => {
+                if (e.detail !== 2 || shouldIgnoreEmptyAction(e.target)) return
+                addEventAtClientY(e.currentTarget, e.clientY)
             }}
         >
             {Array.from({ length: endHour - startHour + 1 }).map((_, i) => {

--- a/docs/issue-logs/issue-27-mobile-swipe-navigation.md
+++ b/docs/issue-logs/issue-27-mobile-swipe-navigation.md
@@ -20,6 +20,7 @@ Date navigation was only available through fixed buttons, and touch gestures on 
 - Added two-finger pinch zoom on the timeline to scale both day width and timeline height together.
 - Highlighted Saturdays, Sundays, and Japanese holidays in the header and day columns.
 - Lowered the current-time line layer so it no longer overlaps the sticky date header text.
+- Restored empty-slot schedule creation by handling both native `dblclick` and the second click of a double-click gesture.
 
 ## Verification
 
@@ -29,4 +30,5 @@ Date navigation was only available through fixed buttons, and touch gestures on 
 - In-app browser: confirmed the timeline still renders cleanly after the navigation control changes.
 - In-app browser: confirmed mouse dragging timeline empty space moves the date range.
 - In-app browser: confirmed weekend and holiday columns are visually distinct and the current-time line stays below the sticky header.
+- Code path check: confirmed empty-slot double-click creation ignores event blocks and interactive controls.
 - Code path check: confirmed swipe navigation ignores interactive targets, cancels on vertical movement, supports mouse and touch pointers, and leaves event-block pointer handlers untouched.


### PR DESCRIPTION
## Summary
- restore empty-slot schedule creation after the timeline drag gesture changes
- handle both native dblclick and the second click of a double-click gesture
- ignore event blocks and interactive controls when creating a new empty-slot schedule
- update the issue #27 implementation log

## Verification
- npx tsc --noEmit
- npm run lint
- npm run build
- in-app browser double-click check confirmed the Quick Add modal opens with the Label field active

## 概要
- タイムラインのドラッグ操作追加後に壊れていた、空き枠ダブルクリックでの予定新規作成を復旧しました
- ネイティブの dblclick と、ダブルクリック2回目の click の両方で新規作成処理が走るようにしました
- イベントブロックやボタン、入力欄などの操作対象上では、空き枠作成が誤って動かないようにしました
- Issue #27 の実装ログを更新しました

## 検証
- npx tsc --noEmit
- npm run lint
- npm run build
- in-app browser で空き枠をダブルクリックし、Quick Add が開いて Label 入力欄が active になることを確認

Refs #27
