### PR TITLE
Improve alarm UX and persist view settings

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ import {
 import { formatDateHeader, getTodayDateKey, parseDateKey, toDateKey } from "../lib/date"
 import { formatJapaneseEraYear } from "../lib/japaneseCalendar"
 import { parseEventItems } from "../lib/storage"
+import { minToHHMM } from "../lib/time"
 
 const STORAGE_KEY = "timeboxing-tool:v1:week-items"
 const GRID_MIN = 15
@@ -170,6 +171,12 @@ export default function Home() {
         enabled: alarmEnabled,
         leadMin: alarmLeadMin,
     })
+    const alarmStatusText = alarmEnabled ? "Enabled" : "Disabled"
+    const notificationPermissionText =
+        alarm.notificationPermission === "unsupported" ? "unsupported" : alarm.notificationPermission
+    const nextAlarmText = alarm.nextToday
+        ? `${alarm.nextToday.label || "(untitled)"} at ${minToHHMM(alarm.nextToday.alarmMin)}`
+        : "No upcoming alarm today"
 
     useEffect(() => {
         const isTyping = () => {
@@ -793,6 +800,28 @@ export default function Home() {
 
                             <section className={SETTINGS_SECTION_CLASS}>
                                 <h3 className="text-sm font-semibold text-gray-900">Alarm</h3>
+                                <div className="grid gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm">
+                                    <div className="flex items-center justify-between gap-3">
+                                        <span className="text-gray-600">Status</span>
+                                        <span
+                                            className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
+                                                alarmEnabled
+                                                    ? "bg-emerald-100 text-emerald-700"
+                                                    : "bg-gray-200 text-gray-700"
+                                            }`}
+                                        >
+                                            {alarmStatusText}
+                                        </span>
+                                    </div>
+                                    <div className="flex items-center justify-between gap-3">
+                                        <span className="text-gray-600">Notification</span>
+                                        <span className="font-medium text-gray-900">{notificationPermissionText}</span>
+                                    </div>
+                                    <div className="flex items-start justify-between gap-3">
+                                        <span className="text-gray-600">Next</span>
+                                        <span className="text-right font-medium text-gray-900">{nextAlarmText}</span>
+                                    </div>
+                                </div>
                                 <div className="flex flex-wrap items-center gap-3 text-sm text-gray-700">
                                     <label className="flex items-center gap-2">
                                         <input
@@ -820,13 +849,25 @@ export default function Home() {
                                     </label>
                                 </div>
 
-                                <button
-                                    className={`${BUTTON_CLASS} mt-3 w-full`}
-                                    type="button"
-                                    onClick={() => alarm.requestNotificationPermission()}
-                                >
-                                    Notification permission
-                                </button>
+                                <div className="mt-3 grid grid-cols-2 gap-2">
+                                    <button
+                                        className={BUTTON_CLASS}
+                                        type="button"
+                                        onClick={() => alarm.requestNotificationPermission()}
+                                        disabled={alarm.notificationPermission === "unsupported"}
+                                    >
+                                        Request notification
+                                    </button>
+                                    <button
+                                        className={BUTTON_CLASS}
+                                        type="button"
+                                        onClick={() => {
+                                            void alarm.testBeep()
+                                        }}
+                                    >
+                                        Test sound
+                                    </button>
+                                </div>
                             </section>
                         </div>
                     </div>

--- a/docs/issue-logs/issue-34-persist-view-options.md
+++ b/docs/issue-logs/issue-34-persist-view-options.md
@@ -1,0 +1,22 @@
+# Issue #34: Persist View Options
+
+## Symptom
+
+The timeline start hour, vertical zoom, horizontal day width zoom, and focused date reset to defaults after reloading the app.
+
+## Root Cause
+
+Event data was persisted in localStorage, but `useViewOptions` kept view preferences only in React state.
+
+## Fix
+
+- Added a dedicated `timeboxing-tool:v1:view-options` localStorage key.
+- Restored saved view options when `useViewOptions` mounts on the client.
+- Persisted `startHour`, `zoom`, `dayWidthZoom`, and `centerDateKey` after the initial load.
+- Clamped numeric settings to their supported ranges and ignored invalid stored dates or broken JSON.
+
+## Verification
+
+- `npm run lint`
+- `npm run build`
+

--- a/docs/issue-logs/issue-36-alarm-status-and-test-controls.md
+++ b/docs/issue-logs/issue-36-alarm-status-and-test-controls.md
@@ -1,0 +1,22 @@
+# Issue #36: Alarm Status and Test Controls
+
+## Symptom
+
+The alarm settings could enable alarms and request notification permission, but users could not clearly see whether alarms were enabled, what the browser notification permission was, or which event would fire next.
+
+## Root Cause
+
+`useAlarm` already exposed the next scheduled alarm and a test sound action, but the settings UI only surfaced the enable checkbox, lead minutes, and a generic notification permission button. The hook also exposed permission as a boolean, which was not enough to distinguish `granted`, `denied`, and `default`.
+
+## Fix
+
+- Added `notificationPermission` to `useAlarm`, preserving the existing `hasNotificationPermission` boolean for compatibility.
+- Added alarm status, notification permission, and next alarm summary rows to the settings modal.
+- Added a user-triggered `Test sound` button.
+- Renamed the notification permission action to `Request notification`.
+
+## Verification
+
+- `npm run lint`
+- `npm run build`
+

--- a/hooks/useAlarm.ts
+++ b/hooks/useAlarm.ts
@@ -25,11 +25,11 @@ type ScheduledAlarmEvent = AlarmEvent & {
 
 const CHECK_INTERVAL_MS = 15_000
 const DUE_GRACE_MS = 90_000
+type NotificationPermissionState = NotificationPermission | "unsupported"
 
 export function useAlarm({ items, enabled, leadMin }: Options) {
-    const [hasNotificationPermission, setHasNotificationPermission] = useState<boolean>(
-        typeof Notification !== "undefined" && Notification.permission === "granted"
-    )
+    const [notificationPermission, setNotificationPermission] =
+        useState<NotificationPermissionState>(getNotificationPermission)
     const [nowMs, setNowMs] = useState(() => Date.now())
 
     const firedRef = useRef<Set<string>>(new Set())
@@ -43,16 +43,16 @@ export function useAlarm({ items, enabled, leadMin }: Options) {
     const requestNotificationPermission = async () => {
         if (typeof Notification === "undefined") return false
         if (Notification.permission === "granted") {
-            setHasNotificationPermission(true)
+            setNotificationPermission("granted")
             return true
         }
         if (Notification.permission === "denied") {
-            setHasNotificationPermission(false)
+            setNotificationPermission("denied")
             return false
         }
         const res = await Notification.requestPermission()
         const ok = res === "granted"
-        setHasNotificationPermission(ok)
+        setNotificationPermission(res)
         return ok
     }
 
@@ -176,11 +176,17 @@ export function useAlarm({ items, enabled, leadMin }: Options) {
 
     return {
         nextToday,
-        hasNotificationPermission,
+        notificationPermission,
+        hasNotificationPermission: notificationPermission === "granted",
         requestNotificationPermission,
         primeAudio,
         testBeep: playBeep,
     }
+}
+
+function getNotificationPermission(): NotificationPermissionState {
+    if (typeof Notification === "undefined") return "unsupported"
+    return Notification.permission
 }
 
 function getAudioContext(audioCtxRef: MutableRefObject<AudioContext | null>) {

--- a/hooks/useViewOptions.ts
+++ b/hooks/useViewOptions.ts
@@ -1,9 +1,12 @@
 "use client"
 
-import { useMemo, useState } from "react"
-import { addDays, getTodayDateKey } from "../lib/date"
+import { useEffect, useMemo, useState } from "react"
+import { addDays, getTodayDateKey, isDateKey } from "../lib/date"
 
 const VISIBLE_DAY_COUNT = 31
+const VIEW_OPTIONS_STORAGE_KEY = "timeboxing-tool:v1:view-options"
+const MIN_START_HOUR = 0
+const MAX_START_HOUR = 12
 export const MIN_ZOOM = 75
 export const MAX_ZOOM = 200
 export const ZOOM_STEP = 5
@@ -12,11 +15,19 @@ export const MAX_DAY_WIDTH_ZOOM = 180
 export const DAY_WIDTH_ZOOM_STEP = 10
 const BASE_DAY_COLUMN_WIDTH = 112
 
+type StoredViewOptions = {
+    startHour?: unknown
+    zoom?: unknown
+    dayWidthZoom?: unknown
+    centerDateKey?: unknown
+}
+
 export function useViewOptions() {
     const [startHour, setStartHour] = useState(6)
     const [zoom, setZoom] = useState(100)
     const [dayWidthZoom, setDayWidthZoom] = useState(100)
     const [centerDateKey, setCenterDateKey] = useState<string>(getTodayDateKey)
+    const [loaded, setLoaded] = useState(false)
 
     const pxPerMin = 0.96 * (zoom / 100)
     const dayColumnMinWidth = Math.round(BASE_DAY_COLUMN_WIDTH * (dayWidthZoom / 100))
@@ -27,26 +38,55 @@ export function useViewOptions() {
         return Array.from({ length: VISIBLE_DAY_COUNT }, (_, index) => addDays(centerDateKey, index))
     }, [centerDateKey])
 
+    useEffect(() => {
+        const saved = parseStoredViewOptions(localStorage.getItem(VIEW_OPTIONS_STORAGE_KEY))
+        if (saved) {
+            // Restore persisted client-only preferences after hydration.
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            if (saved.startHour !== undefined) setStartHour(saved.startHour)
+            if (saved.zoom !== undefined) setZoom(saved.zoom)
+            if (saved.dayWidthZoom !== undefined) setDayWidthZoom(saved.dayWidthZoom)
+            if (saved.centerDateKey !== undefined) setCenterDateKey(saved.centerDateKey)
+        }
+        setLoaded(true)
+    }, [])
+
+    useEffect(() => {
+        if (!loaded) return
+        localStorage.setItem(
+            VIEW_OPTIONS_STORAGE_KEY,
+            JSON.stringify({
+                startHour,
+                zoom,
+                dayWidthZoom,
+                centerDateKey,
+            })
+        )
+    }, [centerDateKey, dayWidthZoom, loaded, startHour, zoom])
+
     const shiftCenter = (delta: number) => {
         setCenterDateKey((current) => addDays(current, delta))
     }
 
+    const updateStartHour = (next: number) => {
+        setStartHour(clamp(next, MIN_START_HOUR, MAX_START_HOUR))
+    }
     const updateZoom = (next: number | ((current: number) => number)) => {
         setZoom((current) => {
             const value = typeof next === "function" ? next(current) : next
-            return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value))
+            return clamp(value, MIN_ZOOM, MAX_ZOOM)
         })
     }
     const updateDayWidthZoom = (next: number | ((current: number) => number)) => {
         setDayWidthZoom((current) => {
             const value = typeof next === "function" ? next(current) : next
-            return Math.min(MAX_DAY_WIDTH_ZOOM, Math.max(MIN_DAY_WIDTH_ZOOM, value))
+            return clamp(value, MIN_DAY_WIDTH_ZOOM, MAX_DAY_WIDTH_ZOOM)
         })
     }
 
     return {
         startHour,
-        setStartHour,
+        setStartHour: updateStartHour,
         zoom,
         setZoom: updateZoom,
         dayWidthZoom,
@@ -60,4 +100,35 @@ export function useViewOptions() {
         viewEndMin,
         visibleDateKeys,
     }
+}
+
+function parseStoredViewOptions(raw: string | null) {
+    if (!raw) return null
+
+    try {
+        const parsed = JSON.parse(raw) as StoredViewOptions
+        if (!parsed || typeof parsed !== "object") return null
+
+        return {
+            startHour:
+                typeof parsed.startHour === "number" && Number.isFinite(parsed.startHour)
+                    ? clamp(parsed.startHour, MIN_START_HOUR, MAX_START_HOUR)
+                    : undefined,
+            zoom:
+                typeof parsed.zoom === "number" && Number.isFinite(parsed.zoom)
+                    ? clamp(parsed.zoom, MIN_ZOOM, MAX_ZOOM)
+                    : undefined,
+            dayWidthZoom:
+                typeof parsed.dayWidthZoom === "number" && Number.isFinite(parsed.dayWidthZoom)
+                    ? clamp(parsed.dayWidthZoom, MIN_DAY_WIDTH_ZOOM, MAX_DAY_WIDTH_ZOOM)
+                    : undefined,
+            centerDateKey: isDateKey(parsed.centerDateKey) ? parsed.centerDateKey : undefined,
+        }
+    } catch {
+        return null
+    }
+}
+
+function clamp(value: number, min: number, max: number) {
+    return Math.min(max, Math.max(min, value))
 }


### PR DESCRIPTION
## Summary
- Add alarm status, notification permission, next alarm, and test sound controls to settings
- Expose full notification permission state from `useAlarm`
- Persist view options in localStorage with validation and clamping
- Add issue logs for #34 and #36

## Verification
- `npm run lint`
- `npm run build`

Closes #34
Closes #36