### PR TITLE
Improve overlapping event layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,6 @@ npm run build
 ## Future Improvements
 
 - Add automated tests for date, time, and storage logic
-- Persist view settings such as start hour and zoom level
-- Improve event layout when three or more events overlap
-- Improve alarm status visibility and test controls
 - Research login-free cross-device sync options
 
 ## License

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ import {
 import { formatDateHeader, getTodayDateKey, parseDateKey, toDateKey } from "../lib/date"
 import { formatJapaneseEraYear } from "../lib/japaneseCalendar"
 import { parseEventItems } from "../lib/storage"
+import { minToHHMM } from "../lib/time"
 
 const STORAGE_KEY = "timeboxing-tool:v1:week-items"
 const GRID_MIN = 15
@@ -170,6 +171,12 @@ export default function Home() {
         enabled: alarmEnabled,
         leadMin: alarmLeadMin,
     })
+    const alarmStatusText = alarmEnabled ? "Enabled" : "Disabled"
+    const notificationPermissionText =
+        alarm.notificationPermission === "unsupported" ? "unsupported" : alarm.notificationPermission
+    const nextAlarmText = alarm.nextToday
+        ? `${alarm.nextToday.label || "(untitled)"} at ${minToHHMM(alarm.nextToday.alarmMin)}`
+        : "No upcoming alarm today"
 
     useEffect(() => {
         const isTyping = () => {
@@ -793,6 +800,28 @@ export default function Home() {
 
                             <section className={SETTINGS_SECTION_CLASS}>
                                 <h3 className="text-sm font-semibold text-gray-900">Alarm</h3>
+                                <div className="grid gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm">
+                                    <div className="flex items-center justify-between gap-3">
+                                        <span className="text-gray-600">Status</span>
+                                        <span
+                                            className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
+                                                alarmEnabled
+                                                    ? "bg-emerald-100 text-emerald-700"
+                                                    : "bg-gray-200 text-gray-700"
+                                            }`}
+                                        >
+                                            {alarmStatusText}
+                                        </span>
+                                    </div>
+                                    <div className="flex items-center justify-between gap-3">
+                                        <span className="text-gray-600">Notification</span>
+                                        <span className="font-medium text-gray-900">{notificationPermissionText}</span>
+                                    </div>
+                                    <div className="flex items-start justify-between gap-3">
+                                        <span className="text-gray-600">Next</span>
+                                        <span className="text-right font-medium text-gray-900">{nextAlarmText}</span>
+                                    </div>
+                                </div>
                                 <div className="flex flex-wrap items-center gap-3 text-sm text-gray-700">
                                     <label className="flex items-center gap-2">
                                         <input
@@ -820,13 +849,25 @@ export default function Home() {
                                     </label>
                                 </div>
 
-                                <button
-                                    className={`${BUTTON_CLASS} mt-3 w-full`}
-                                    type="button"
-                                    onClick={() => alarm.requestNotificationPermission()}
-                                >
-                                    Notification permission
-                                </button>
+                                <div className="mt-3 grid grid-cols-2 gap-2">
+                                    <button
+                                        className={BUTTON_CLASS}
+                                        type="button"
+                                        onClick={() => alarm.requestNotificationPermission()}
+                                        disabled={alarm.notificationPermission === "unsupported"}
+                                    >
+                                        Request notification
+                                    </button>
+                                    <button
+                                        className={BUTTON_CLASS}
+                                        type="button"
+                                        onClick={() => {
+                                            void alarm.testBeep()
+                                        }}
+                                    >
+                                        Test sound
+                                    </button>
+                                </div>
                             </section>
                         </div>
                     </div>

--- a/components/WeekGrid.tsx
+++ b/components/WeekGrid.tsx
@@ -5,6 +5,7 @@ import { DayColumn } from "./week/DayColumn"
 import { formatDateHeader, getTodayDateKey, parseDateKey } from "../lib/date"
 import { getJapaneseHolidayName } from "../lib/japaneseCalendar"
 import { minToHHMM } from "../lib/time"
+import { computeOverlapLayout, type LayoutInfo } from "./week/layout"
 
 export type EventItem = {
     id: string
@@ -17,8 +18,6 @@ export type EventItem = {
 }
 
 const TIME_COLUMN_WIDTH = 56
-
-type LayoutInfo = { lane: 0 | 1; lanesCount: 1 | 2 }
 type DayTone = "weekday" | "saturday" | "rest"
 
 function getDayTone(dateKey: string, holidayName: string | null): DayTone {
@@ -33,52 +32,6 @@ function getHeaderClass(isToday: boolean, dayTone: DayTone) {
     if (dayTone === "rest") return "bg-rose-50 text-rose-700 ring-1 ring-inset ring-rose-100"
     if (dayTone === "saturday") return "bg-sky-50 text-sky-700 ring-1 ring-inset ring-sky-100"
     return "text-gray-800"
-}
-
-function computeTwoLaneLayout(items: EventItem[]): Map<string, LayoutInfo> {
-    const sorted = [...items].sort((a, b) => a.startMin - b.startMin || a.endMin - b.endMin)
-    const result = new Map<string, LayoutInfo>()
-
-    let laneEnd0 = -1
-    let laneEnd1 = -1
-
-    for (const item of sorted) {
-        const overlapsLane0 = item.startMin < laneEnd0
-        const overlapsLane1 = item.startMin < laneEnd1
-
-        if (!overlapsLane0) {
-            result.set(item.id, { lane: 0, lanesCount: overlapsLane1 ? 2 : 1 })
-            laneEnd0 = item.endMin
-            continue
-        }
-
-        if (!overlapsLane1) {
-            result.set(item.id, { lane: 1, lanesCount: 2 })
-            laneEnd1 = item.endMin
-            continue
-        }
-
-        result.set(item.id, { lane: 1, lanesCount: 2 })
-        laneEnd1 = Math.max(laneEnd1, item.endMin)
-    }
-
-    for (let i = 0; i < sorted.length; i += 1) {
-        for (let j = i + 1; j < sorted.length; j += 1) {
-            const a = sorted[i]
-            const b = sorted[j]
-            const overlap = a.startMin < b.endMin && b.startMin < a.endMin
-            if (!overlap) continue
-
-            const layoutA = result.get(a.id)
-            const layoutB = result.get(b.id)
-            if (!layoutA || !layoutB || layoutA.lane === layoutB.lane) continue
-
-            result.set(a.id, { ...layoutA, lanesCount: 2 })
-            result.set(b.id, { ...layoutB, lanesCount: 2 })
-        }
-    }
-
-    return result
 }
 
 export function WeekGrid({
@@ -128,7 +81,7 @@ export function WeekGrid({
 
     const layoutByDate: Record<string, Map<string, LayoutInfo>> = {}
     for (const dateKey of visibleDateKeys) {
-        layoutByDate[dateKey] = computeTwoLaneLayout(itemsByDate[dateKey] ?? [])
+        layoutByDate[dateKey] = computeOverlapLayout(itemsByDate[dateKey] ?? [])
     }
 
     const startHour = Math.floor(viewStartMin / 60)

--- a/components/week/EventBlock.tsx
+++ b/components/week/EventBlock.tsx
@@ -47,16 +47,17 @@ export function EventBlock({
         }
     })
 
-    // Split overlapping events into up to two lanes.
+    // Split overlapping events into as many lanes as the overlap group needs.
     const laneGap = 4
-    const lanesCount = layout.lanesCount
-    const lane = layout.lane
+    const lanesCount = Math.max(1, layout.lanesCount)
+    const lane = Math.min(Math.max(0, layout.lane), lanesCount - 1)
     const widthStyle =
         lanesCount === 1
             ? { left: 4, right: 4 }
-            : lane === 0
-                ? { left: 4, right: `calc(50% + ${laneGap / 2}px)` }
-                : { left: `calc(50% - ${laneGap / 2}px)`, right: 4 }
+            : {
+                  left: `calc(4px + ${lane} * ((100% - ${8 + laneGap * (lanesCount - 1)}px) / ${lanesCount} + ${laneGap}px))`,
+                  width: `calc((100% - ${8 + laneGap * (lanesCount - 1)}px) / ${lanesCount})`,
+              }
 
     const MIN_DURATION = gridMin
     const resizeHandleRight = firstUrl ? 36 : 16

--- a/components/week/layout.ts
+++ b/components/week/layout.ts
@@ -2,57 +2,45 @@ import type { EventItem } from "@/components/WeekGrid"
 
 export const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const
 
-export type LayoutInfo = { lane: 0 | 1; lanesCount: 1 | 2 }
+export type LayoutInfo = { lane: number; lanesCount: number }
 
-/**
- * 2件重複までを左右分割で表示するための簡易レイアウト。
- * - 3件以上重複は lanesCount=2 に押し込む（次に「3件以上は警告」へ拡張できる）
- */
-export function computeTwoLaneLayout(items: EventItem[]): Map<string, LayoutInfo> {
+export function computeOverlapLayout(items: EventItem[]): Map<string, LayoutInfo> {
     const sorted = [...items].sort((a, b) => a.startMin - b.startMin || a.endMin - b.endMin)
-    const res = new Map<string, LayoutInfo>()
+    const result = new Map<string, LayoutInfo>()
+    let groupIds: string[] = []
+    let laneEnds: number[] = []
+    let groupEnd = -1
 
-    let laneEnd0 = -1
-    let laneEnd1 = -1
-
-    for (const it of sorted) {
-        const overlaps0 = it.startMin < laneEnd0
-        const overlaps1 = it.startMin < laneEnd1
-
-        if (!overlaps0) {
-            const needTwo = overlaps1
-            res.set(it.id, { lane: 0, lanesCount: needTwo ? 2 : 1 })
-            laneEnd0 = it.endMin
-            continue
+    const finishGroup = () => {
+        const lanesCount = Math.max(1, laneEnds.length)
+        for (const id of groupIds) {
+            const layout = result.get(id)
+            if (layout) result.set(id, { ...layout, lanesCount })
         }
-
-        if (!overlaps1) {
-            res.set(it.id, { lane: 1, lanesCount: 2 })
-            laneEnd1 = it.endMin
-            continue
-        }
-
-        // 3+ overlap (not fully supported)
-        res.set(it.id, { lane: 1, lanesCount: 2 })
-        laneEnd1 = Math.max(laneEnd1, it.endMin)
+        groupIds = []
+        laneEnds = []
+        groupEnd = -1
     }
 
-    // Fix lanesCount: if any overlap in different lanes, mark both as 2
-    for (let i = 0; i < sorted.length; i++) {
-        for (let j = i + 1; j < sorted.length; j++) {
-            const a = sorted[i]
-            const b = sorted[j]
-            const overlap = a.startMin < b.endMin && b.startMin < a.endMin
-            if (!overlap) continue
-            const la = res.get(a.id)
-            const lb = res.get(b.id)
-            if (!la || !lb) continue
-            if (la.lane !== lb.lane) {
-                res.set(a.id, { ...la, lanesCount: 2 })
-                res.set(b.id, { ...lb, lanesCount: 2 })
-            }
+    for (const item of sorted) {
+        if (groupIds.length > 0 && item.startMin >= groupEnd) {
+            finishGroup()
         }
+
+        let lane = laneEnds.findIndex((endMin) => item.startMin >= endMin)
+        if (lane === -1) {
+            lane = laneEnds.length
+            laneEnds.push(item.endMin)
+        } else {
+            laneEnds[lane] = item.endMin
+        }
+
+        groupIds.push(item.id)
+        groupEnd = Math.max(groupEnd, item.endMin)
+        result.set(item.id, { lane, lanesCount: 1 })
     }
 
-    return res
+    if (groupIds.length > 0) finishGroup()
+
+    return result
 }

--- a/docs/issue-logs/issue-34-persist-view-options.md
+++ b/docs/issue-logs/issue-34-persist-view-options.md
@@ -1,0 +1,22 @@
+# Issue #34: Persist View Options
+
+## Symptom
+
+The timeline start hour, vertical zoom, horizontal day width zoom, and focused date reset to defaults after reloading the app.
+
+## Root Cause
+
+Event data was persisted in localStorage, but `useViewOptions` kept view preferences only in React state.
+
+## Fix
+
+- Added a dedicated `timeboxing-tool:v1:view-options` localStorage key.
+- Restored saved view options when `useViewOptions` mounts on the client.
+- Persisted `startHour`, `zoom`, `dayWidthZoom`, and `centerDateKey` after the initial load.
+- Clamped numeric settings to their supported ranges and ignored invalid stored dates or broken JSON.
+
+## Verification
+
+- `npm run lint`
+- `npm run build`
+

--- a/docs/issue-logs/issue-36-alarm-status-and-test-controls.md
+++ b/docs/issue-logs/issue-36-alarm-status-and-test-controls.md
@@ -1,0 +1,22 @@
+# Issue #36: Alarm Status and Test Controls
+
+## Symptom
+
+The alarm settings could enable alarms and request notification permission, but users could not clearly see whether alarms were enabled, what the browser notification permission was, or which event would fire next.
+
+## Root Cause
+
+`useAlarm` already exposed the next scheduled alarm and a test sound action, but the settings UI only surfaced the enable checkbox, lead minutes, and a generic notification permission button. The hook also exposed permission as a boolean, which was not enough to distinguish `granted`, `denied`, and `default`.
+
+## Fix
+
+- Added `notificationPermission` to `useAlarm`, preserving the existing `hasNotificationPermission` boolean for compatibility.
+- Added alarm status, notification permission, and next alarm summary rows to the settings modal.
+- Added a user-triggered `Test sound` button.
+- Renamed the notification permission action to `Request notification`.
+
+## Verification
+
+- `npm run lint`
+- `npm run build`
+

--- a/docs/issue-logs/issue-38-overlap-layout.md
+++ b/docs/issue-logs/issue-38-overlap-layout.md
@@ -1,0 +1,21 @@
+# Issue #38: Overlap Layout for Three or More Events
+
+## Symptom
+
+When three or more events overlapped in the same day column, the layout still collapsed them into two lanes. Some events could cover each other or become difficult to select.
+
+## Root Cause
+
+`WeekGrid` used a local two-lane layout helper, while `components/week/layout.ts` also had an older two-lane helper. Both models capped `lanesCount` at 2.
+
+## Fix
+
+- Replaced the two-lane helper with `computeOverlapLayout`, which assigns as many lanes as an overlap group needs.
+- Shared `LayoutInfo` from `components/week/layout.ts` so the grid and event block use the same layout contract.
+- Updated `EventBlock` width calculation to divide the available column width across any number of lanes.
+- Removed completed Future Improvements entries from the English README.
+
+## Verification
+
+- `npm run lint`
+- `npm run build`

--- a/hooks/useAlarm.ts
+++ b/hooks/useAlarm.ts
@@ -25,11 +25,11 @@ type ScheduledAlarmEvent = AlarmEvent & {
 
 const CHECK_INTERVAL_MS = 15_000
 const DUE_GRACE_MS = 90_000
+type NotificationPermissionState = NotificationPermission | "unsupported"
 
 export function useAlarm({ items, enabled, leadMin }: Options) {
-    const [hasNotificationPermission, setHasNotificationPermission] = useState<boolean>(
-        typeof Notification !== "undefined" && Notification.permission === "granted"
-    )
+    const [notificationPermission, setNotificationPermission] =
+        useState<NotificationPermissionState>(getNotificationPermission)
     const [nowMs, setNowMs] = useState(() => Date.now())
 
     const firedRef = useRef<Set<string>>(new Set())
@@ -43,16 +43,16 @@ export function useAlarm({ items, enabled, leadMin }: Options) {
     const requestNotificationPermission = async () => {
         if (typeof Notification === "undefined") return false
         if (Notification.permission === "granted") {
-            setHasNotificationPermission(true)
+            setNotificationPermission("granted")
             return true
         }
         if (Notification.permission === "denied") {
-            setHasNotificationPermission(false)
+            setNotificationPermission("denied")
             return false
         }
         const res = await Notification.requestPermission()
         const ok = res === "granted"
-        setHasNotificationPermission(ok)
+        setNotificationPermission(res)
         return ok
     }
 
@@ -176,11 +176,17 @@ export function useAlarm({ items, enabled, leadMin }: Options) {
 
     return {
         nextToday,
-        hasNotificationPermission,
+        notificationPermission,
+        hasNotificationPermission: notificationPermission === "granted",
         requestNotificationPermission,
         primeAudio,
         testBeep: playBeep,
     }
+}
+
+function getNotificationPermission(): NotificationPermissionState {
+    if (typeof Notification === "undefined") return "unsupported"
+    return Notification.permission
 }
 
 function getAudioContext(audioCtxRef: MutableRefObject<AudioContext | null>) {

--- a/hooks/useViewOptions.ts
+++ b/hooks/useViewOptions.ts
@@ -1,9 +1,12 @@
 "use client"
 
-import { useMemo, useState } from "react"
-import { addDays, getTodayDateKey } from "../lib/date"
+import { useEffect, useMemo, useState } from "react"
+import { addDays, getTodayDateKey, isDateKey } from "../lib/date"
 
 const VISIBLE_DAY_COUNT = 31
+const VIEW_OPTIONS_STORAGE_KEY = "timeboxing-tool:v1:view-options"
+const MIN_START_HOUR = 0
+const MAX_START_HOUR = 12
 export const MIN_ZOOM = 75
 export const MAX_ZOOM = 200
 export const ZOOM_STEP = 5
@@ -12,11 +15,19 @@ export const MAX_DAY_WIDTH_ZOOM = 180
 export const DAY_WIDTH_ZOOM_STEP = 10
 const BASE_DAY_COLUMN_WIDTH = 112
 
+type StoredViewOptions = {
+    startHour?: unknown
+    zoom?: unknown
+    dayWidthZoom?: unknown
+    centerDateKey?: unknown
+}
+
 export function useViewOptions() {
     const [startHour, setStartHour] = useState(6)
     const [zoom, setZoom] = useState(100)
     const [dayWidthZoom, setDayWidthZoom] = useState(100)
     const [centerDateKey, setCenterDateKey] = useState<string>(getTodayDateKey)
+    const [loaded, setLoaded] = useState(false)
 
     const pxPerMin = 0.96 * (zoom / 100)
     const dayColumnMinWidth = Math.round(BASE_DAY_COLUMN_WIDTH * (dayWidthZoom / 100))
@@ -27,26 +38,55 @@ export function useViewOptions() {
         return Array.from({ length: VISIBLE_DAY_COUNT }, (_, index) => addDays(centerDateKey, index))
     }, [centerDateKey])
 
+    useEffect(() => {
+        const saved = parseStoredViewOptions(localStorage.getItem(VIEW_OPTIONS_STORAGE_KEY))
+        if (saved) {
+            // Restore persisted client-only preferences after hydration.
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            if (saved.startHour !== undefined) setStartHour(saved.startHour)
+            if (saved.zoom !== undefined) setZoom(saved.zoom)
+            if (saved.dayWidthZoom !== undefined) setDayWidthZoom(saved.dayWidthZoom)
+            if (saved.centerDateKey !== undefined) setCenterDateKey(saved.centerDateKey)
+        }
+        setLoaded(true)
+    }, [])
+
+    useEffect(() => {
+        if (!loaded) return
+        localStorage.setItem(
+            VIEW_OPTIONS_STORAGE_KEY,
+            JSON.stringify({
+                startHour,
+                zoom,
+                dayWidthZoom,
+                centerDateKey,
+            })
+        )
+    }, [centerDateKey, dayWidthZoom, loaded, startHour, zoom])
+
     const shiftCenter = (delta: number) => {
         setCenterDateKey((current) => addDays(current, delta))
     }
 
+    const updateStartHour = (next: number) => {
+        setStartHour(clamp(next, MIN_START_HOUR, MAX_START_HOUR))
+    }
     const updateZoom = (next: number | ((current: number) => number)) => {
         setZoom((current) => {
             const value = typeof next === "function" ? next(current) : next
-            return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value))
+            return clamp(value, MIN_ZOOM, MAX_ZOOM)
         })
     }
     const updateDayWidthZoom = (next: number | ((current: number) => number)) => {
         setDayWidthZoom((current) => {
             const value = typeof next === "function" ? next(current) : next
-            return Math.min(MAX_DAY_WIDTH_ZOOM, Math.max(MIN_DAY_WIDTH_ZOOM, value))
+            return clamp(value, MIN_DAY_WIDTH_ZOOM, MAX_DAY_WIDTH_ZOOM)
         })
     }
 
     return {
         startHour,
-        setStartHour,
+        setStartHour: updateStartHour,
         zoom,
         setZoom: updateZoom,
         dayWidthZoom,
@@ -60,4 +100,35 @@ export function useViewOptions() {
         viewEndMin,
         visibleDateKeys,
     }
+}
+
+function parseStoredViewOptions(raw: string | null) {
+    if (!raw) return null
+
+    try {
+        const parsed = JSON.parse(raw) as StoredViewOptions
+        if (!parsed || typeof parsed !== "object") return null
+
+        return {
+            startHour:
+                typeof parsed.startHour === "number" && Number.isFinite(parsed.startHour)
+                    ? clamp(parsed.startHour, MIN_START_HOUR, MAX_START_HOUR)
+                    : undefined,
+            zoom:
+                typeof parsed.zoom === "number" && Number.isFinite(parsed.zoom)
+                    ? clamp(parsed.zoom, MIN_ZOOM, MAX_ZOOM)
+                    : undefined,
+            dayWidthZoom:
+                typeof parsed.dayWidthZoom === "number" && Number.isFinite(parsed.dayWidthZoom)
+                    ? clamp(parsed.dayWidthZoom, MIN_DAY_WIDTH_ZOOM, MAX_DAY_WIDTH_ZOOM)
+                    : undefined,
+            centerDateKey: isDateKey(parsed.centerDateKey) ? parsed.centerDateKey : undefined,
+        }
+    } catch {
+        return null
+    }
+}
+
+function clamp(value: number, min: number, max: number) {
+    return Math.min(max, Math.max(min, value))
 }


### PR DESCRIPTION
## Summary

- Improve overlapping event layout so 3+ simultaneous events are split into separate lanes
- Share the overlap layout helper between `WeekGrid` and `EventBlock`
- Remove completed Future Improvements entries from the README
- Add an issue log for the overlap layout fix

## Verification

- `npm run lint`
- `npm run build`
