### PR TITLE
Add regression tests for scheduling logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # testing
 /coverage
+/.test-out
 
 # next.js
 /.next/

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,130 +1,31 @@
 "use client"
 
-import { ChangeEvent, type PointerEvent as ReactPointerEvent, useEffect, useMemo, useRef, useState } from "react"
-import { QuickAddModal, type QuickAddState } from "../components/QuickAddModal"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { CalendarPopover, getMonthLabel } from "../components/CalendarPopover"
 import { EventDetailsPopover } from "../components/EventDetailsPopover"
+import { FloatingControls } from "../components/FloatingControls"
+import { QuickAddModal, type QuickAddState } from "../components/QuickAddModal"
+import { TransferToast } from "../components/TransferToast"
 import { type EventItem, WeekGrid } from "../components/WeekGrid"
+import { SettingsDialog } from "../components/SettingsDialog"
 import { useAlarm } from "../hooks/useAlarm"
+import { useJsonTransfer } from "../hooks/useJsonTransfer"
 import { useNowMin } from "../hooks/useNowMin"
 import { useSelection } from "../hooks/useSelection"
+import { useSwipeNavigation } from "../hooks/useSwipeNavigation"
 import { useTimeboxingItems } from "../hooks/useTimeboxingItems"
-import {
-    DAY_WIDTH_ZOOM_STEP,
-    MAX_DAY_WIDTH_ZOOM,
-    MAX_ZOOM,
-    MIN_DAY_WIDTH_ZOOM,
-    MIN_ZOOM,
-    ZOOM_STEP,
-    useViewOptions,
-} from "../hooks/useViewOptions"
-import { formatDateHeader, getTodayDateKey, parseDateKey, toDateKey } from "../lib/date"
-import { formatJapaneseEraYear } from "../lib/japaneseCalendar"
-import { parseEventItems } from "../lib/storage"
-import { minToHHMM } from "../lib/time"
+import { DAY_WIDTH_ZOOM_STEP, ZOOM_STEP, useViewOptions } from "../hooks/useViewOptions"
+import { formatDateHeader, getTodayDateKey } from "../lib/date"
 
 const STORAGE_KEY = "timeboxing-tool:v1:week-items"
 const GRID_MIN = 15
 const DEFAULT_DURATION = 30
-const BUTTON_CLASS =
-    "rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
-const SETTINGS_SECTION_CLASS = "space-y-3 border-t border-gray-100 pt-4 first:border-t-0 first:pt-0"
-const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const
-const SWIPE_MIN_X = 64
-const SWIPE_MAX_TAP_MS = 700
-const SWIPE_VERTICAL_CANCEL_Y = 32
-const SWIPE_HORIZONTAL_RATIO = 1.4
-const SWIPE_EXCLUDED_TARGETS = 'button, input, textarea, select, a, [data-eventblock="1"]'
-const PINCH_MIN_DISTANCE = 40
-
-type SwipeStart = {
-    pointerId: number
-    pointerType: string
-    x: number
-    y: number
-    time: number
-    cancelled: boolean
-}
-
-type TouchPoint = {
-    x: number
-    y: number
-}
-
-type PinchStart = {
-    distance: number
-    zoom: number
-    dayWidthZoom: number
-}
-
-function buildExportFilename() {
-    const stamp = new Date().toISOString().slice(0, 10)
-    return `timebox-events-${stamp}.json`
-}
-
-function downloadJson(items: EventItem[]) {
-    const blob = new Blob([JSON.stringify(items, null, 2)], {
-        type: "application/json",
-    })
-    const url = URL.createObjectURL(blob)
-    const anchor = document.createElement("a")
-    anchor.href = url
-    anchor.download = buildExportFilename()
-    anchor.click()
-    URL.revokeObjectURL(url)
-}
-
-function getMonthLabel(dateKey: string) {
-    const date = parseDateKey(dateKey)
-    const monthName = date.toLocaleString("en-US", { month: "long" })
-    return `${monthName} ${date.getFullYear()} (${formatJapaneseEraYear(dateKey)})`
-}
-
-function addMonths(dateKey: string, delta: number) {
-    const date = parseDateKey(dateKey)
-    const day = date.getDate()
-    const next = new Date(date.getFullYear(), date.getMonth() + delta, 1)
-    const lastDay = new Date(next.getFullYear(), next.getMonth() + 1, 0).getDate()
-    next.setDate(Math.min(day, lastDay))
-    return toDateKey(next)
-}
-
-function getMonthCalendarDays(monthDateKey: string) {
-    const monthDate = parseDateKey(monthDateKey)
-    const firstOfMonth = new Date(monthDate.getFullYear(), monthDate.getMonth(), 1)
-    const firstGridDate = new Date(firstOfMonth)
-    firstGridDate.setDate(firstGridDate.getDate() - ((firstGridDate.getDay() + 6) % 7))
-
-    return Array.from({ length: 42 }, (_, index) => {
-        const date = new Date(firstGridDate)
-        date.setDate(firstGridDate.getDate() + index)
-        return {
-            dateKey: toDateKey(date),
-            day: date.getDate(),
-            inMonth: date.getMonth() === monthDate.getMonth(),
-        }
-    })
-}
-
-function clamp(value: number, min: number, max: number) {
-    return Math.min(max, Math.max(min, value))
-}
-
-function snapToStep(value: number, step: number) {
-    return Math.round(value / step) * step
-}
-
-function getPinchDistance(points: TouchPoint[]) {
-    if (points.length < 2) return 0
-    return Math.hypot(points[0].x - points[1].x, points[0].y - points[1].y)
-}
 
 export default function Home() {
     const { items, setItems, loaded } = useTimeboxingItems(STORAGE_KEY)
     const nowMin = useNowMin(15000)
     const [alarmEnabled, setAlarmEnabled] = useState(false)
     const [alarmLeadMin, setAlarmLeadMin] = useState(0)
-    const [transferMessage, setTransferMessage] = useState<string | null>(null)
-    const [transferState, setTransferState] = useState<"success" | "error" | null>(null)
     const [settingsOpen, setSettingsOpen] = useState(false)
     const [calendarOpen, setCalendarOpen] = useState(false)
     const [calendarMonthKey, setCalendarMonthKey] = useState(getTodayDateKey)
@@ -149,10 +50,6 @@ export default function Home() {
     const { selectedId, selectedAnchor, selectedItem, open, close } = useSelection(items)
     const [quickAdd, setQuickAdd] = useState<QuickAddState | null>(null)
     const clipboardRef = useRef<EventItem | null>(null)
-    const importInputRef = useRef<HTMLInputElement | null>(null)
-    const swipeStartRef = useRef<SwipeStart | null>(null)
-    const activeTouchPointsRef = useRef<Map<number, TouchPoint>>(new Map())
-    const pinchStartRef = useRef<PinchStart | null>(null)
 
     const alarmItems = useMemo(
         () =>
@@ -171,12 +68,26 @@ export default function Home() {
         enabled: alarmEnabled,
         leadMin: alarmLeadMin,
     })
-    const alarmStatusText = alarmEnabled ? "Enabled" : "Disabled"
-    const notificationPermissionText =
-        alarm.notificationPermission === "unsupported" ? "unsupported" : alarm.notificationPermission
-    const nextAlarmText = alarm.nextToday
-        ? `${alarm.nextToday.label || "(untitled)"} at ${minToHHMM(alarm.nextToday.alarmMin)}`
-        : "No upcoming alarm today"
+
+    const { importInputRef, transferMessage, transferState, exportJson, importJson, openImportPicker } =
+        useJsonTransfer({
+            items,
+            setItems,
+            onImportSuccess: close,
+        })
+
+    const moveDate = (direction: -1 | 1) => shiftCenter(direction)
+    const zoomTimeline = (direction: -1 | 1) => setZoom((current) => current + direction * ZOOM_STEP)
+    const zoomDayWidth = (direction: -1 | 1) =>
+        setDayWidthZoom((current) => current + direction * DAY_WIDTH_ZOOM_STEP)
+
+    const { startSwipe, trackSwipe, finishSwipe, cancelSwipe } = useSwipeNavigation({
+        zoom,
+        dayWidthZoom,
+        setZoom,
+        setDayWidthZoom,
+        onMoveDate: moveDate,
+    })
 
     useEffect(() => {
         const isTyping = () => {
@@ -283,388 +194,42 @@ export default function Home() {
         setQuickAdd(null)
     }
 
-    const handleExport = () => {
-        downloadJson(items)
-        setTransferMessage(`Exported ${items.length} event${items.length === 1 ? "" : "s"} to JSON.`)
-        setTransferState("success")
-    }
-
-    const handleImport = async (event: ChangeEvent<HTMLInputElement>) => {
-        const file = event.target.files?.[0]
-        if (!file) return
-
-        try {
-            const raw = await file.text()
-            const parsed = parseEventItems(raw)
-
-            if (!parsed) {
-                setTransferMessage("Import failed. The JSON file is invalid or missing required fields.")
-                setTransferState("error")
-                return
-            }
-
-            setItems(parsed)
-            close()
-            setTransferMessage(`Imported ${parsed.length} event${parsed.length === 1 ? "" : "s"} from ${file.name}.`)
-            setTransferState("success")
-        } catch {
-            setTransferMessage("Import failed. The file could not be read.")
-            setTransferState("error")
-        } finally {
-            event.target.value = ""
-        }
-    }
-
-    const dayLabel = formatDateHeader(centerDateKey)
-    const visibleMonthLabel = getMonthLabel(visibleDateKeys[0] ?? centerDateKey)
-    const todayKey = getTodayDateKey()
-    const calendarDays = getMonthCalendarDays(calendarMonthKey)
-    const moveDate = (direction: -1 | 1) => shiftCenter(direction)
-    const zoomTimeline = (direction: -1 | 1) => setZoom((current) => current + direction * ZOOM_STEP)
-    const zoomDayWidth = (direction: -1 | 1) =>
-        setDayWidthZoom((current) => current + direction * DAY_WIDTH_ZOOM_STEP)
     const jumpToDate = (dateKey: string) => {
         setCenterDateKey(dateKey)
         setCalendarMonthKey(dateKey)
         setCalendarOpen(false)
     }
-    const jumpToToday = () => jumpToDate(todayKey)
-    const beginPinch = () => {
-        const distance = getPinchDistance([...activeTouchPointsRef.current.values()])
-        if (distance < PINCH_MIN_DISTANCE) return
 
-        pinchStartRef.current = {
-            distance,
-            zoom,
-            dayWidthZoom,
-        }
-    }
-    const updatePinch = () => {
-        const pinchStart = pinchStartRef.current
-        if (!pinchStart) return
-
-        const distance = getPinchDistance([...activeTouchPointsRef.current.values()])
-        if (distance < PINCH_MIN_DISTANCE) return
-
-        const scale = distance / pinchStart.distance
-        const nextZoom = clamp(snapToStep(pinchStart.zoom * scale, ZOOM_STEP), MIN_ZOOM, MAX_ZOOM)
-        const nextDayWidthZoom = clamp(
-            snapToStep(pinchStart.dayWidthZoom * scale, DAY_WIDTH_ZOOM_STEP),
-            MIN_DAY_WIDTH_ZOOM,
-            MAX_DAY_WIDTH_ZOOM
-        )
-
-        setZoom(nextZoom)
-        setDayWidthZoom(nextDayWidthZoom)
-    }
-    const startSwipe = (event: ReactPointerEvent<HTMLDivElement>) => {
-        if (event.pointerType === "touch") {
-            activeTouchPointsRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY })
-            if (activeTouchPointsRef.current.size >= 2) {
-                swipeStartRef.current = null
-                beginPinch()
-                return
-            }
-        }
-
-        if (event.pointerType === "mouse" && event.button !== 0) return
-        if (event.pointerType !== "touch" && event.pointerType !== "mouse") return
-
-        const target = event.target as HTMLElement | null
-        if (target?.closest(SWIPE_EXCLUDED_TARGETS)) return
-
-        swipeStartRef.current = {
-            pointerId: event.pointerId,
-            pointerType: event.pointerType,
-            x: event.clientX,
-            y: event.clientY,
-            time: performance.now(),
-            cancelled: false,
-        }
-    }
-    const trackSwipe = (event: ReactPointerEvent<HTMLDivElement>) => {
-        if (event.pointerType === "touch" && activeTouchPointsRef.current.has(event.pointerId)) {
-            activeTouchPointsRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY })
-            if (pinchStartRef.current) {
-                updatePinch()
-                return
-            }
-        }
-
-        const start = swipeStartRef.current
-        if (!start || event.pointerId !== start.pointerId || event.pointerType !== start.pointerType) return
-        if (event.pointerType === "mouse" && event.buttons !== 1) return
-
-        const dx = event.clientX - start.x
-        const dy = event.clientY - start.y
-        const horizontalIntent = Math.abs(dx) >= Math.abs(dy) * SWIPE_HORIZONTAL_RATIO
-        const verticalIntent = Math.abs(dy) > SWIPE_VERTICAL_CANCEL_Y && !horizontalIntent
-        if (verticalIntent) start.cancelled = true
-    }
-    const finishSwipe = (event: ReactPointerEvent<HTMLDivElement>) => {
-        if (event.pointerType === "touch") {
-            activeTouchPointsRef.current.delete(event.pointerId)
-            if (pinchStartRef.current) {
-                if (activeTouchPointsRef.current.size < 2) pinchStartRef.current = null
-                swipeStartRef.current = null
-                return
-            }
-        }
-
-        const start = swipeStartRef.current
-        swipeStartRef.current = null
-        if (!start || start.cancelled || event.pointerId !== start.pointerId || event.pointerType !== start.pointerType) return
-
-        const dx = event.clientX - start.x
-        const dy = event.clientY - start.y
-        const elapsed = performance.now() - start.time
-        if (elapsed > SWIPE_MAX_TAP_MS) return
-        if (Math.abs(dx) < SWIPE_MIN_X || Math.abs(dx) < Math.abs(dy) * SWIPE_HORIZONTAL_RATIO) return
-
-        moveDate(dx < 0 ? 1 : -1)
-    }
+    const todayKey = getTodayDateKey()
+    const visibleMonthLabel = getMonthLabel(visibleDateKeys[0] ?? centerDateKey)
 
     return (
         <main className="flex h-screen flex-col overflow-hidden bg-gray-50 text-gray-900">
-            <div className="fixed left-3 top-3 z-40 rounded-full border border-gray-200 bg-white/95 px-4 py-2 text-sm font-semibold text-gray-800 shadow-lg shadow-gray-900/10 backdrop-blur sm:left-4 sm:top-4">
-                {visibleMonthLabel}
-            </div>
+            <FloatingControls
+                visibleMonthLabel={visibleMonthLabel}
+                dayWidthZoom={dayWidthZoom}
+                zoom={zoom}
+                onMoveDate={moveDate}
+                onOpenSettings={() => setSettingsOpen(true)}
+                onZoomDayWidth={zoomDayWidth}
+                onZoomTimeline={zoomTimeline}
+            />
 
-            <div className="fixed bottom-3 left-1/2 z-40 hidden -translate-x-1/2 items-center gap-2 rounded-full border border-gray-200 bg-white/95 p-1 shadow-lg shadow-gray-900/10 backdrop-blur sm:bottom-4 sm:flex">
-                <button
-                    className="flex h-9 w-9 items-center justify-center rounded-full text-gray-700 transition hover:bg-gray-100"
-                    type="button"
-                    aria-label="Previous dates"
-                    onClick={() => moveDate(-1)}
-                >
-                    <svg
-                        aria-hidden="true"
-                        className="h-5 w-5"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="2"
-                        viewBox="0 0 24 24"
-                    >
-                        <path d="m15 18-6-6 6-6" />
-                    </svg>
-                </button>
-                <button
-                    className="flex h-9 w-9 items-center justify-center rounded-full text-gray-700 transition hover:bg-gray-100"
-                    type="button"
-                    aria-label="Next dates"
-                    onClick={() => moveDate(1)}
-                >
-                    <svg
-                        aria-hidden="true"
-                        className="h-5 w-5"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="2"
-                        viewBox="0 0 24 24"
-                    >
-                        <path d="m9 18 6-6-6-6" />
-                    </svg>
-                </button>
-            </div>
+            <CalendarPopover
+                open={calendarOpen}
+                monthDateKey={calendarMonthKey}
+                centerDateKey={centerDateKey}
+                todayDateKey={todayKey}
+                onOpenChange={(openNext) => {
+                    setCalendarMonthKey(centerDateKey)
+                    setCalendarOpen(openNext)
+                }}
+                onMonthChange={setCalendarMonthKey}
+                onToday={() => jumpToDate(todayKey)}
+                onSelectDate={jumpToDate}
+            />
 
-            <button
-                className="fixed right-3 top-3 z-40 flex h-11 w-11 items-center justify-center rounded-full border border-gray-200 bg-white/95 text-gray-700 shadow-lg shadow-gray-900/10 backdrop-blur transition hover:bg-white sm:right-4 sm:top-4"
-                type="button"
-                aria-label="Open settings"
-                onClick={() => setSettingsOpen(true)}
-            >
-                <svg
-                    aria-hidden="true"
-                    className="h-5 w-5"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    viewBox="0 0 24 24"
-                >
-                    <path d="M12 15.5A3.5 3.5 0 1 0 12 8a3.5 3.5 0 0 0 0 7.5Z" />
-                    <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.2a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1A1.7 1.7 0 0 0 4.6 15a1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.2a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1A2 2 0 1 1 7.1 4.3l.1.1A1.7 1.7 0 0 0 9 4.7a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.2a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8 1.7 1.7 0 0 0 1.5 1h.2a2 2 0 1 1 0 4h-.2a1.7 1.7 0 0 0-1.4 1Z" />
-                </svg>
-            </button>
-            <div className="fixed right-16 top-3 z-40 flex h-11 items-center gap-1 rounded-full border border-gray-200 bg-white/95 p-1 text-gray-700 shadow-lg shadow-gray-900/10 backdrop-blur sm:right-[4.25rem] sm:top-4">
-                <span className="pl-2 text-xs font-semibold text-gray-500" aria-hidden="true">
-                    H
-                </span>
-                <button
-                    className="flex h-9 w-9 items-center justify-center rounded-full text-base font-semibold transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
-                    type="button"
-                    aria-label="Compress day width"
-                    disabled={dayWidthZoom <= MIN_DAY_WIDTH_ZOOM}
-                    onClick={() => zoomDayWidth(-1)}
-                >
-                    -
-                </button>
-                <button
-                    className="flex h-9 w-9 items-center justify-center rounded-full text-base font-semibold transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
-                    type="button"
-                    aria-label="Expand day width"
-                    disabled={dayWidthZoom >= MAX_DAY_WIDTH_ZOOM}
-                    onClick={() => zoomDayWidth(1)}
-                >
-                    +
-                </button>
-                <div className="mx-0.5 h-6 w-px bg-gray-200" aria-hidden="true" />
-                <span className="text-xs font-semibold text-gray-500" aria-hidden="true">
-                    V
-                </span>
-                <button
-                    className="flex h-9 w-9 items-center justify-center rounded-full text-base font-semibold transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
-                    type="button"
-                    aria-label="Compress timeline height"
-                    disabled={zoom <= MIN_ZOOM}
-                    onClick={() => zoomTimeline(-1)}
-                >
-                    -
-                </button>
-                <button
-                    className="flex h-9 w-9 items-center justify-center rounded-full text-base font-semibold transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
-                    type="button"
-                    aria-label="Expand timeline height"
-                    disabled={zoom >= MAX_ZOOM}
-                    onClick={() => zoomTimeline(1)}
-                >
-                    +
-                </button>
-            </div>
-            <div className="fixed right-3 top-16 z-50 sm:right-4 sm:top-[4.25rem]" data-calendar-root="1">
-                <button
-                    className="flex h-11 w-11 items-center justify-center rounded-full border border-gray-200 bg-white/95 text-gray-700 shadow-lg shadow-gray-900/10 backdrop-blur transition hover:bg-white"
-                    type="button"
-                    aria-label="Open calendar"
-                    onClick={() => {
-                        setCalendarMonthKey(centerDateKey)
-                        setCalendarOpen((open) => !open)
-                    }}
-                >
-                    <svg
-                        aria-hidden="true"
-                        className="h-5 w-5"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="2"
-                        viewBox="0 0 24 24"
-                    >
-                        <path d="M8 2v4" />
-                        <path d="M16 2v4" />
-                        <path d="M3 10h18" />
-                        <rect x="3" y="4" width="18" height="18" rx="2" />
-                    </svg>
-                </button>
-
-                {calendarOpen ? (
-                    <div
-                        className="mt-2 w-80 rounded-xl border border-gray-200 bg-white p-3 shadow-2xl shadow-gray-900/15"
-                        onMouseDown={(event) => event.stopPropagation()}
-                    >
-                        <div className="mb-3 flex items-center gap-2">
-                            <button
-                                className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 text-gray-700 transition hover:bg-gray-50"
-                                type="button"
-                                aria-label="Previous month"
-                                onClick={() => setCalendarMonthKey((current) => addMonths(current, -1))}
-                            >
-                                <svg
-                                    aria-hidden="true"
-                                    className="h-4 w-4"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth="2"
-                                    viewBox="0 0 24 24"
-                                >
-                                    <path d="m15 18-6-6 6-6" />
-                                </svg>
-                            </button>
-                            <div className="flex-1 text-center text-sm font-semibold text-gray-900">
-                                {getMonthLabel(calendarMonthKey)}
-                            </div>
-                            <button
-                                className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 text-gray-700 transition hover:bg-gray-50"
-                                type="button"
-                                aria-label="Next month"
-                                onClick={() => setCalendarMonthKey((current) => addMonths(current, 1))}
-                            >
-                                <svg
-                                    aria-hidden="true"
-                                    className="h-4 w-4"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth="2"
-                                    viewBox="0 0 24 24"
-                                >
-                                    <path d="m9 18 6-6-6-6" />
-                                </svg>
-                            </button>
-                        </div>
-                        <button
-                            className="mb-3 h-9 w-full rounded-lg border border-gray-200 bg-white text-sm font-semibold text-gray-800 transition hover:bg-gray-50"
-                            type="button"
-                            onClick={jumpToToday}
-                        >
-                            Today
-                        </button>
-
-                        <div className="grid grid-cols-7 gap-1 text-center text-[11px] font-semibold uppercase text-gray-500">
-                            {WEEKDAY_LABELS.map((label) => (
-                                <div key={label} className="py-1">
-                                    {label}
-                                </div>
-                            ))}
-                        </div>
-                        <div className="grid grid-cols-7 gap-1">
-                            {calendarDays.map((day) => {
-                                const isSelected = day.dateKey === centerDateKey
-                                const isToday = day.dateKey === todayKey
-                                return (
-                                    <button
-                                        key={day.dateKey}
-                                        className={`h-9 rounded-lg text-sm font-medium transition ${
-                                            isSelected
-                                                ? "bg-blue-600 text-white hover:bg-blue-700"
-                                                : isToday
-                                                  ? "border border-red-300 bg-red-50 text-red-700 hover:bg-red-100"
-                                                  : day.inMonth
-                                                    ? "text-gray-800 hover:bg-gray-100"
-                                                    : "text-gray-400 hover:bg-gray-50"
-                                        }`}
-                                        type="button"
-                                        onClick={() => jumpToDate(day.dateKey)}
-                                    >
-                                        {day.day}
-                                    </button>
-                                )
-                            })}
-                        </div>
-                    </div>
-                ) : null}
-            </div>
-
-            {transferMessage ? (
-                <div
-                    className={`fixed left-3 right-16 top-3 z-30 rounded-lg px-3 py-2 text-sm shadow-lg sm:left-auto sm:right-20 sm:top-4 sm:w-96 ${
-                        transferState === "error"
-                            ? "border border-rose-200 bg-rose-50 text-rose-700"
-                            : "border border-emerald-200 bg-emerald-50 text-emerald-700"
-                    }`}
-                >
-                    {transferMessage}
-                </div>
-            ) : null}
+            <TransferToast message={transferMessage} state={transferState} />
 
             <input
                 ref={importInputRef}
@@ -672,7 +237,7 @@ export default function Home() {
                 accept="application/json,.json"
                 className="hidden"
                 onChange={(event) => {
-                    void handleImport(event)
+                    void importJson(event)
                 }}
             />
 
@@ -682,11 +247,7 @@ export default function Home() {
                     onPointerDown={startSwipe}
                     onPointerMove={trackSwipe}
                     onPointerUp={finishSwipe}
-                    onPointerCancel={(event) => {
-                        activeTouchPointsRef.current.delete(event.pointerId)
-                        if (activeTouchPointsRef.current.size < 2) pinchStartRef.current = null
-                        swipeStartRef.current = null
-                    }}
+                    onPointerCancel={cancelSwipe}
                 >
                     <WeekGrid
                         items={items}
@@ -730,149 +291,21 @@ export default function Home() {
                 />
             ) : null}
 
-            {settingsOpen ? (
-                <div
-                    className="fixed inset-0 z-50 flex items-start justify-center bg-gray-950/35 px-3 py-4 sm:items-center"
-                    role="dialog"
-                    aria-modal="true"
-                    aria-labelledby="settings-title"
-                    onMouseDown={() => setSettingsOpen(false)}
-                >
-                    <div
-                        className="flex max-h-[calc(100vh-2rem)] w-full max-w-lg flex-col overflow-hidden rounded-xl bg-white shadow-2xl"
-                        onMouseDown={(event) => event.stopPropagation()}
-                    >
-                        <div className="flex items-center gap-3 border-b border-gray-200 px-4 py-3">
-                            <h2 id="settings-title" className="text-base font-semibold text-gray-900">
-                                Settings
-                            </h2>
-                            <button
-                                className="ml-auto rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
-                                type="button"
-                                onClick={() => setSettingsOpen(false)}
-                            >
-                                Close
-                            </button>
-                        </div>
-
-                        <div className="space-y-5 overflow-y-auto px-4 py-4">
-                            <section className={SETTINGS_SECTION_CLASS}>
-                                <h3 className="text-sm font-semibold text-gray-900">View</h3>
-                                <div className="rounded-lg border border-dashed border-gray-300 px-3 py-2 text-sm text-gray-600">
-                                    Focus: {dayLabel}
-                                </div>
-                            </section>
-
-                            <section className={SETTINGS_SECTION_CLASS}>
-                                <h3 className="text-sm font-semibold text-gray-900">Timeline</h3>
-                                <label className="block text-sm text-gray-700">
-                                    <div className="mb-2">Start hour</div>
-                                    <select
-                                        className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900"
-                                        value={startHour}
-                                        onChange={(event) => setStartHour(Number(event.target.value))}
-                                    >
-                                        {Array.from({ length: 13 }, (_, hour) => (
-                                            <option key={hour} value={hour}>
-                                                {hour}:00
-                                            </option>
-                                        ))}
-                                    </select>
-                                </label>
-                            </section>
-
-                            <section className={SETTINGS_SECTION_CLASS}>
-                                <h3 className="text-sm font-semibold text-gray-900">Backup</h3>
-                                <div className="grid grid-cols-2 gap-2">
-                                    <button className={BUTTON_CLASS} type="button" onClick={handleExport} disabled={!loaded}>
-                                        Export JSON
-                                    </button>
-                                    <button
-                                        className={BUTTON_CLASS}
-                                        type="button"
-                                        onClick={() => importInputRef.current?.click()}
-                                        disabled={!loaded}
-                                    >
-                                        Import JSON
-                                    </button>
-                                </div>
-                            </section>
-
-                            <section className={SETTINGS_SECTION_CLASS}>
-                                <h3 className="text-sm font-semibold text-gray-900">Alarm</h3>
-                                <div className="grid gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm">
-                                    <div className="flex items-center justify-between gap-3">
-                                        <span className="text-gray-600">Status</span>
-                                        <span
-                                            className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
-                                                alarmEnabled
-                                                    ? "bg-emerald-100 text-emerald-700"
-                                                    : "bg-gray-200 text-gray-700"
-                                            }`}
-                                        >
-                                            {alarmStatusText}
-                                        </span>
-                                    </div>
-                                    <div className="flex items-center justify-between gap-3">
-                                        <span className="text-gray-600">Notification</span>
-                                        <span className="font-medium text-gray-900">{notificationPermissionText}</span>
-                                    </div>
-                                    <div className="flex items-start justify-between gap-3">
-                                        <span className="text-gray-600">Next</span>
-                                        <span className="text-right font-medium text-gray-900">{nextAlarmText}</span>
-                                    </div>
-                                </div>
-                                <div className="flex flex-wrap items-center gap-3 text-sm text-gray-700">
-                                    <label className="flex items-center gap-2">
-                                        <input
-                                            type="checkbox"
-                                            checked={alarmEnabled}
-                                            onChange={(event) => {
-                                                const checked = event.target.checked
-                                                setAlarmEnabled(checked)
-                                                if (checked) void alarm.primeAudio()
-                                            }}
-                                        />
-                                        Alarm
-                                    </label>
-
-                                    <label className="ml-auto flex items-center gap-2">
-                                        Lead min
-                                        <input
-                                            type="number"
-                                            min={0}
-                                            max={120}
-                                            value={alarmLeadMin}
-                                            onChange={(event) => setAlarmLeadMin(Number(event.target.value || 0))}
-                                            className="w-16 rounded border border-gray-200 bg-white px-2 py-1"
-                                        />
-                                    </label>
-                                </div>
-
-                                <div className="mt-3 grid grid-cols-2 gap-2">
-                                    <button
-                                        className={BUTTON_CLASS}
-                                        type="button"
-                                        onClick={() => alarm.requestNotificationPermission()}
-                                        disabled={alarm.notificationPermission === "unsupported"}
-                                    >
-                                        Request notification
-                                    </button>
-                                    <button
-                                        className={BUTTON_CLASS}
-                                        type="button"
-                                        onClick={() => {
-                                            void alarm.testBeep()
-                                        }}
-                                    >
-                                        Test sound
-                                    </button>
-                                </div>
-                            </section>
-                        </div>
-                    </div>
-                </div>
-            ) : null}
+            <SettingsDialog
+                open={settingsOpen}
+                loaded={loaded}
+                focusLabel={formatDateHeader(centerDateKey)}
+                startHour={startHour}
+                alarmEnabled={alarmEnabled}
+                alarmLeadMin={alarmLeadMin}
+                alarm={alarm}
+                onClose={() => setSettingsOpen(false)}
+                onStartHourChange={setStartHour}
+                onExport={exportJson}
+                onImport={openImportPicker}
+                onAlarmEnabledChange={setAlarmEnabled}
+                onAlarmLeadMinChange={setAlarmLeadMin}
+            />
         </main>
     )
 }

--- a/components/CalendarPopover.tsx
+++ b/components/CalendarPopover.tsx
@@ -1,0 +1,195 @@
+"use client"
+
+import { parseDateKey, toDateKey } from "../lib/date"
+import { formatJapaneseEraYear } from "../lib/japaneseCalendar"
+
+const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const
+
+type CalendarDay = {
+    dateKey: string
+    day: number
+    inMonth: boolean
+}
+
+export function getMonthLabel(dateKey: string) {
+    const date = parseDateKey(dateKey)
+    const monthName = date.toLocaleString("en-US", { month: "long" })
+    return `${monthName} ${date.getFullYear()} (${formatJapaneseEraYear(dateKey)})`
+}
+
+function addMonths(dateKey: string, delta: number) {
+    const date = parseDateKey(dateKey)
+    const day = date.getDate()
+    const next = new Date(date.getFullYear(), date.getMonth() + delta, 1)
+    const lastDay = new Date(next.getFullYear(), next.getMonth() + 1, 0).getDate()
+    next.setDate(Math.min(day, lastDay))
+    return toDateKey(next)
+}
+
+function getMonthCalendarDays(monthDateKey: string): CalendarDay[] {
+    const monthDate = parseDateKey(monthDateKey)
+    const firstOfMonth = new Date(monthDate.getFullYear(), monthDate.getMonth(), 1)
+    const firstGridDate = new Date(firstOfMonth)
+    firstGridDate.setDate(firstGridDate.getDate() - ((firstGridDate.getDay() + 6) % 7))
+
+    return Array.from({ length: 42 }, (_, index) => {
+        const date = new Date(firstGridDate)
+        date.setDate(firstGridDate.getDate() + index)
+        return {
+            dateKey: toDateKey(date),
+            day: date.getDate(),
+            inMonth: date.getMonth() === monthDate.getMonth(),
+        }
+    })
+}
+
+export function CalendarPopover({
+    open,
+    monthDateKey,
+    centerDateKey,
+    todayDateKey,
+    onOpenChange,
+    onMonthChange,
+    onToday,
+    onSelectDate,
+}: {
+    open: boolean
+    monthDateKey: string
+    centerDateKey: string
+    todayDateKey: string
+    onOpenChange: (open: boolean) => void
+    onMonthChange: (dateKey: string) => void
+    onToday: () => void
+    onSelectDate: (dateKey: string) => void
+}) {
+    const calendarDays = getMonthCalendarDays(monthDateKey)
+
+    return (
+        <div className="fixed right-3 top-16 z-50 sm:right-4 sm:top-[4.25rem]" data-calendar-root="1">
+            <button
+                className="flex h-11 w-11 items-center justify-center rounded-full border border-gray-200 bg-white/95 text-gray-700 shadow-lg shadow-gray-900/10 backdrop-blur transition hover:bg-white"
+                type="button"
+                aria-label="Open calendar"
+                onClick={() => onOpenChange(!open)}
+            >
+                <svg
+                    aria-hidden="true"
+                    className="h-5 w-5"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    viewBox="0 0 24 24"
+                >
+                    <path d="M8 2v4" />
+                    <path d="M16 2v4" />
+                    <path d="M3 10h18" />
+                    <rect x="3" y="4" width="18" height="18" rx="2" />
+                </svg>
+            </button>
+
+            {open ? (
+                <div
+                    className="mt-2 w-80 rounded-xl border border-gray-200 bg-white p-3 shadow-2xl shadow-gray-900/15"
+                    onMouseDown={(event) => event.stopPropagation()}
+                >
+                    <div className="mb-3 flex items-center gap-2">
+                        <button
+                            className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 text-gray-700 transition hover:bg-gray-50"
+                            type="button"
+                            aria-label="Previous month"
+                            onClick={() => onMonthChange(addMonths(monthDateKey, -1))}
+                        >
+                            <ChevronLeftIcon />
+                        </button>
+                        <div className="flex-1 text-center text-sm font-semibold text-gray-900">
+                            {getMonthLabel(monthDateKey)}
+                        </div>
+                        <button
+                            className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 text-gray-700 transition hover:bg-gray-50"
+                            type="button"
+                            aria-label="Next month"
+                            onClick={() => onMonthChange(addMonths(monthDateKey, 1))}
+                        >
+                            <ChevronRightIcon />
+                        </button>
+                    </div>
+                    <button
+                        className="mb-3 h-9 w-full rounded-lg border border-gray-200 bg-white text-sm font-semibold text-gray-800 transition hover:bg-gray-50"
+                        type="button"
+                        onClick={onToday}
+                    >
+                        Today
+                    </button>
+
+                    <div className="grid grid-cols-7 gap-1 text-center text-[11px] font-semibold uppercase text-gray-500">
+                        {WEEKDAY_LABELS.map((label) => (
+                            <div key={label} className="py-1">
+                                {label}
+                            </div>
+                        ))}
+                    </div>
+                    <div className="grid grid-cols-7 gap-1">
+                        {calendarDays.map((day) => {
+                            const isSelected = day.dateKey === centerDateKey
+                            const isToday = day.dateKey === todayDateKey
+                            return (
+                                <button
+                                    key={day.dateKey}
+                                    className={`h-9 rounded-lg text-sm font-medium transition ${
+                                        isSelected
+                                            ? "bg-blue-600 text-white hover:bg-blue-700"
+                                            : isToday
+                                              ? "border border-red-300 bg-red-50 text-red-700 hover:bg-red-100"
+                                              : day.inMonth
+                                                ? "text-gray-800 hover:bg-gray-100"
+                                                : "text-gray-400 hover:bg-gray-50"
+                                    }`}
+                                    type="button"
+                                    onClick={() => onSelectDate(day.dateKey)}
+                                >
+                                    {day.day}
+                                </button>
+                            )
+                        })}
+                    </div>
+                </div>
+            ) : null}
+        </div>
+    )
+}
+
+function ChevronLeftIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            className="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+        >
+            <path d="m15 18-6-6 6-6" />
+        </svg>
+    )
+}
+
+function ChevronRightIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            className="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+        >
+            <path d="m9 18 6-6-6-6" />
+        </svg>
+    )
+}

--- a/components/FloatingControls.tsx
+++ b/components/FloatingControls.tsx
@@ -1,0 +1,188 @@
+"use client"
+
+import type { ReactNode } from "react"
+import {
+    MAX_DAY_WIDTH_ZOOM,
+    MAX_ZOOM,
+    MIN_DAY_WIDTH_ZOOM,
+    MIN_ZOOM,
+} from "../hooks/useViewOptions"
+
+export function FloatingControls({
+    visibleMonthLabel,
+    dayWidthZoom,
+    zoom,
+    onMoveDate,
+    onOpenSettings,
+    onZoomDayWidth,
+    onZoomTimeline,
+}: {
+    visibleMonthLabel: string
+    dayWidthZoom: number
+    zoom: number
+    onMoveDate: (direction: -1 | 1) => void
+    onOpenSettings: () => void
+    onZoomDayWidth: (direction: -1 | 1) => void
+    onZoomTimeline: (direction: -1 | 1) => void
+}) {
+    return (
+        <>
+            <div className="fixed left-3 top-3 z-40 rounded-full border border-gray-200 bg-white/95 px-4 py-2 text-sm font-semibold text-gray-800 shadow-lg shadow-gray-900/10 backdrop-blur sm:left-4 sm:top-4">
+                {visibleMonthLabel}
+            </div>
+
+            <div className="fixed bottom-3 left-1/2 z-40 hidden -translate-x-1/2 items-center gap-2 rounded-full border border-gray-200 bg-white/95 p-1 shadow-lg shadow-gray-900/10 backdrop-blur sm:bottom-4 sm:flex">
+                <IconButton ariaLabel="Previous dates" onClick={() => onMoveDate(-1)}>
+                    <ChevronLeftIcon />
+                </IconButton>
+                <IconButton ariaLabel="Next dates" onClick={() => onMoveDate(1)}>
+                    <ChevronRightIcon />
+                </IconButton>
+            </div>
+
+            <button
+                className="fixed right-3 top-3 z-40 flex h-11 w-11 items-center justify-center rounded-full border border-gray-200 bg-white/95 text-gray-700 shadow-lg shadow-gray-900/10 backdrop-blur transition hover:bg-white sm:right-4 sm:top-4"
+                type="button"
+                aria-label="Open settings"
+                onClick={onOpenSettings}
+            >
+                <SettingsIcon />
+            </button>
+
+            <div className="fixed right-16 top-3 z-40 flex h-11 items-center gap-1 rounded-full border border-gray-200 bg-white/95 p-1 text-gray-700 shadow-lg shadow-gray-900/10 backdrop-blur sm:right-[4.25rem] sm:top-4">
+                <span className="pl-2 text-xs font-semibold text-gray-500" aria-hidden="true">
+                    H
+                </span>
+                <ZoomButton
+                    ariaLabel="Compress day width"
+                    disabled={dayWidthZoom <= MIN_DAY_WIDTH_ZOOM}
+                    onClick={() => onZoomDayWidth(-1)}
+                >
+                    -
+                </ZoomButton>
+                <ZoomButton
+                    ariaLabel="Expand day width"
+                    disabled={dayWidthZoom >= MAX_DAY_WIDTH_ZOOM}
+                    onClick={() => onZoomDayWidth(1)}
+                >
+                    +
+                </ZoomButton>
+                <div className="mx-0.5 h-6 w-px bg-gray-200" aria-hidden="true" />
+                <span className="text-xs font-semibold text-gray-500" aria-hidden="true">
+                    V
+                </span>
+                <ZoomButton
+                    ariaLabel="Compress timeline height"
+                    disabled={zoom <= MIN_ZOOM}
+                    onClick={() => onZoomTimeline(-1)}
+                >
+                    -
+                </ZoomButton>
+                <ZoomButton
+                    ariaLabel="Expand timeline height"
+                    disabled={zoom >= MAX_ZOOM}
+                    onClick={() => onZoomTimeline(1)}
+                >
+                    +
+                </ZoomButton>
+            </div>
+        </>
+    )
+}
+
+function IconButton({
+    ariaLabel,
+    children,
+    onClick,
+}: {
+    ariaLabel: string
+    children: ReactNode
+    onClick: () => void
+}) {
+    return (
+        <button
+            className="flex h-9 w-9 items-center justify-center rounded-full text-gray-700 transition hover:bg-gray-100"
+            type="button"
+            aria-label={ariaLabel}
+            onClick={onClick}
+        >
+            {children}
+        </button>
+    )
+}
+
+function ZoomButton({
+    ariaLabel,
+    children,
+    disabled,
+    onClick,
+}: {
+    ariaLabel: string
+    children: ReactNode
+    disabled: boolean
+    onClick: () => void
+}) {
+    return (
+        <button
+            className="flex h-9 w-9 items-center justify-center rounded-full text-base font-semibold transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+            type="button"
+            aria-label={ariaLabel}
+            disabled={disabled}
+            onClick={onClick}
+        >
+            {children}
+        </button>
+    )
+}
+
+function ChevronLeftIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+        >
+            <path d="m15 18-6-6 6-6" />
+        </svg>
+    )
+}
+
+function ChevronRightIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+        >
+            <path d="m9 18 6-6-6-6" />
+        </svg>
+    )
+}
+
+function SettingsIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+        >
+            <path d="M12 15.5A3.5 3.5 0 1 0 12 8a3.5 3.5 0 0 0 0 7.5Z" />
+            <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.2a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1A1.7 1.7 0 0 0 4.6 15a1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.2a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1A2 2 0 1 1 7.1 4.3l.1.1A1.7 1.7 0 0 0 9 4.7a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.2a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8 1.7 1.7 0 0 0 1.5 1h.2a2 2 0 1 1 0 4h-.2a1.7 1.7 0 0 0-1.4 1Z" />
+        </svg>
+    )
+}

--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import { minToHHMM } from "../lib/time"
+import type { UseAlarmResult } from "../hooks/useAlarm"
+
+const BUTTON_CLASS =
+    "rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+const SETTINGS_SECTION_CLASS = "space-y-3 border-t border-gray-100 pt-4 first:border-t-0 first:pt-0"
+
+export function SettingsDialog({
+    open,
+    loaded,
+    focusLabel,
+    startHour,
+    alarmEnabled,
+    alarmLeadMin,
+    alarm,
+    onClose,
+    onStartHourChange,
+    onExport,
+    onImport,
+    onAlarmEnabledChange,
+    onAlarmLeadMinChange,
+}: {
+    open: boolean
+    loaded: boolean
+    focusLabel: string
+    startHour: number
+    alarmEnabled: boolean
+    alarmLeadMin: number
+    alarm: UseAlarmResult
+    onClose: () => void
+    onStartHourChange: (hour: number) => void
+    onExport: () => void
+    onImport: () => void
+    onAlarmEnabledChange: (enabled: boolean) => void
+    onAlarmLeadMinChange: (leadMin: number) => void
+}) {
+    if (!open) return null
+
+    const alarmStatusText = alarmEnabled ? "Enabled" : "Disabled"
+    const notificationPermissionText =
+        alarm.notificationPermission === "unsupported" ? "unsupported" : alarm.notificationPermission
+    const nextAlarmText = alarm.nextToday
+        ? `${alarm.nextToday.label || "(untitled)"} at ${minToHHMM(alarm.nextToday.alarmMin)}`
+        : "No upcoming alarm today"
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-start justify-center bg-gray-950/35 px-3 py-4 sm:items-center"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="settings-title"
+            onMouseDown={onClose}
+        >
+            <div
+                className="flex max-h-[calc(100vh-2rem)] w-full max-w-lg flex-col overflow-hidden rounded-xl bg-white shadow-2xl"
+                onMouseDown={(event) => event.stopPropagation()}
+            >
+                <div className="flex items-center gap-3 border-b border-gray-200 px-4 py-3">
+                    <h2 id="settings-title" className="text-base font-semibold text-gray-900">
+                        Settings
+                    </h2>
+                    <button
+                        className="ml-auto rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+                        type="button"
+                        onClick={onClose}
+                    >
+                        Close
+                    </button>
+                </div>
+
+                <div className="space-y-5 overflow-y-auto px-4 py-4">
+                    <section className={SETTINGS_SECTION_CLASS}>
+                        <h3 className="text-sm font-semibold text-gray-900">View</h3>
+                        <div className="rounded-lg border border-dashed border-gray-300 px-3 py-2 text-sm text-gray-600">
+                            Focus: {focusLabel}
+                        </div>
+                    </section>
+
+                    <section className={SETTINGS_SECTION_CLASS}>
+                        <h3 className="text-sm font-semibold text-gray-900">Timeline</h3>
+                        <label className="block text-sm text-gray-700">
+                            <div className="mb-2">Start hour</div>
+                            <select
+                                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900"
+                                value={startHour}
+                                onChange={(event) => onStartHourChange(Number(event.target.value))}
+                            >
+                                {Array.from({ length: 13 }, (_, hour) => (
+                                    <option key={hour} value={hour}>
+                                        {hour}:00
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+                    </section>
+
+                    <section className={SETTINGS_SECTION_CLASS}>
+                        <h3 className="text-sm font-semibold text-gray-900">Backup</h3>
+                        <div className="grid grid-cols-2 gap-2">
+                            <button className={BUTTON_CLASS} type="button" onClick={onExport} disabled={!loaded}>
+                                Export JSON
+                            </button>
+                            <button className={BUTTON_CLASS} type="button" onClick={onImport} disabled={!loaded}>
+                                Import JSON
+                            </button>
+                        </div>
+                    </section>
+
+                    <section className={SETTINGS_SECTION_CLASS}>
+                        <h3 className="text-sm font-semibold text-gray-900">Alarm</h3>
+                        <div className="grid gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm">
+                            <div className="flex items-center justify-between gap-3">
+                                <span className="text-gray-600">Status</span>
+                                <span
+                                    className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
+                                        alarmEnabled ? "bg-emerald-100 text-emerald-700" : "bg-gray-200 text-gray-700"
+                                    }`}
+                                >
+                                    {alarmStatusText}
+                                </span>
+                            </div>
+                            <div className="flex items-center justify-between gap-3">
+                                <span className="text-gray-600">Notification</span>
+                                <span className="font-medium text-gray-900">{notificationPermissionText}</span>
+                            </div>
+                            <div className="flex items-start justify-between gap-3">
+                                <span className="text-gray-600">Next</span>
+                                <span className="text-right font-medium text-gray-900">{nextAlarmText}</span>
+                            </div>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-3 text-sm text-gray-700">
+                            <label className="flex items-center gap-2">
+                                <input
+                                    type="checkbox"
+                                    checked={alarmEnabled}
+                                    onChange={(event) => {
+                                        const checked = event.target.checked
+                                        onAlarmEnabledChange(checked)
+                                        if (checked) void alarm.primeAudio()
+                                    }}
+                                />
+                                Alarm
+                            </label>
+
+                            <label className="ml-auto flex items-center gap-2">
+                                Lead min
+                                <input
+                                    type="number"
+                                    min={0}
+                                    max={120}
+                                    value={alarmLeadMin}
+                                    onChange={(event) => onAlarmLeadMinChange(Number(event.target.value || 0))}
+                                    className="w-16 rounded border border-gray-200 bg-white px-2 py-1"
+                                />
+                            </label>
+                        </div>
+
+                        <div className="mt-3 grid grid-cols-2 gap-2">
+                            <button
+                                className={BUTTON_CLASS}
+                                type="button"
+                                onClick={() => alarm.requestNotificationPermission()}
+                                disabled={alarm.notificationPermission === "unsupported"}
+                            >
+                                Request notification
+                            </button>
+                            <button
+                                className={BUTTON_CLASS}
+                                type="button"
+                                onClick={() => {
+                                    void alarm.testBeep()
+                                }}
+                            >
+                                Test sound
+                            </button>
+                        </div>
+                    </section>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/components/TransferToast.tsx
+++ b/components/TransferToast.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+export type TransferState = "success" | "error" | null
+
+export function TransferToast({ message, state }: { message: string | null; state: TransferState }) {
+    if (!message) return null
+
+    return (
+        <div
+            className={`fixed left-3 right-16 top-3 z-30 rounded-lg px-3 py-2 text-sm shadow-lg sm:left-auto sm:right-20 sm:top-4 sm:w-96 ${
+                state === "error"
+                    ? "border border-rose-200 bg-rose-50 text-rose-700"
+                    : "border border-emerald-200 bg-emerald-50 text-emerald-700"
+            }`}
+        >
+            {message}
+        </div>
+    )
+}

--- a/docs/issue-logs/README.md
+++ b/docs/issue-logs/README.md
@@ -8,6 +8,10 @@ Each log should capture:
 - the chosen fix
 - how the fix was verified
 
+## Logs
+
+- [Issue #33: Split Home Component Responsibilities](./issue-33-home-component-split.md)
+
 ## Japanese
 
 このディレクトリには、issue 修正時の短い実装ログを保存します。

--- a/docs/issue-logs/issue-33-home-component-split.md
+++ b/docs/issue-logs/issue-33-home-component-split.md
@@ -1,0 +1,24 @@
+# Issue #33: Split Home Component Responsibilities
+
+## Symptom
+
+`app/page.tsx` owned top-level app state, settings UI, calendar UI, JSON import/export, swipe navigation, pinch zoom, and event editing glue in one large component. This made future review and regression checks harder.
+
+## Root Cause
+
+Feature work had accumulated in `Home` because shared controls and interaction logic were implemented inline instead of behind focused component or hook boundaries.
+
+## Fix
+
+- Moved the calendar popover and month calendar helpers into `components/CalendarPopover.tsx`.
+- Moved settings dialog rendering into `components/SettingsDialog.tsx`.
+- Moved floating date, settings, and zoom controls into `components/FloatingControls.tsx`.
+- Moved JSON import/export state and file input handling into `hooks/useJsonTransfer.ts`.
+- Moved swipe navigation and pinch zoom pointer handling into `hooks/useSwipeNavigation.ts`.
+- Kept `Home` focused on state wiring, event CRUD glue, and the main `WeekGrid` layout.
+
+## Verification
+
+- `npx tsc --noEmit`
+- `npm run lint`
+- `npm run build`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ const eslintConfig = defineConfig([
   globalIgnores([
     // Default ignores of eslint-config-next:
     ".next/**",
+    ".test-out/**",
     "out/**",
     "build/**",
     "next-env.d.ts",

--- a/hooks/useAlarm.ts
+++ b/hooks/useAlarm.ts
@@ -27,6 +27,8 @@ const CHECK_INTERVAL_MS = 15_000
 const DUE_GRACE_MS = 90_000
 type NotificationPermissionState = NotificationPermission | "unsupported"
 
+export type UseAlarmResult = ReturnType<typeof useAlarm>
+
 export function useAlarm({ items, enabled, leadMin }: Options) {
     const [notificationPermission, setNotificationPermission] =
         useState<NotificationPermissionState>(getNotificationPermission)

--- a/hooks/useAlarm.ts
+++ b/hooks/useAlarm.ts
@@ -1,26 +1,14 @@
 "use client"
 
 import { useEffect, useMemo, useRef, useState, type MutableRefObject } from "react"
-import { toDateKey } from "../lib/date"
+import { getTodaySchedule, type AlarmEvent } from "../lib/alarmSchedule"
 
-export type AlarmEvent = {
-    id: string
-    dateKey: string
-    startMin: number
-    endMin: number
-    label: string
-}
+export type { AlarmEvent }
 
 type Options = {
     items: AlarmEvent[]
     enabled: boolean
     leadMin: number // 0 means fire at the event start time.
-}
-
-type ScheduledAlarmEvent = AlarmEvent & {
-    alarmMin: number
-    targetMs: number
-    fireKey: string
 }
 
 const CHECK_INTERVAL_MS = 15_000
@@ -203,27 +191,6 @@ function getAudioContext(audioCtxRef: MutableRefObject<AudioContext | null>) {
     if (!AudioCtx) return null
     audioCtxRef.current = new AudioCtx()
     return audioCtxRef.current
-}
-
-function getTodaySchedule(items: AlarmEvent[], leadMin: number, nowMs: number): ScheduledAlarmEvent[] {
-    const now = new Date(nowMs)
-    const todayKey = toDateKey(now)
-    const startOfToday = new Date(now)
-    startOfToday.setHours(0, 0, 0, 0)
-
-    return items
-        .filter((x) => x.dateKey === todayKey)
-        .map((x) => {
-            const alarmMin = Math.max(0, x.startMin - leadMin)
-            return {
-                ...x,
-                alarmMin,
-                targetMs: startOfToday.getTime() + alarmMin * 60_000,
-                fireKey: `${todayKey}:${x.id}:${alarmMin}:${x.startMin}:${x.endMin}`,
-            }
-        })
-        .filter((x) => x.alarmMin >= 0 && x.alarmMin <= 1440)
-        .sort((a, b) => a.targetMs - b.targetMs)
 }
 
 function pad(min: number) {

--- a/hooks/useJsonTransfer.ts
+++ b/hooks/useJsonTransfer.ts
@@ -1,0 +1,80 @@
+"use client"
+
+import { type ChangeEvent, type Dispatch, type SetStateAction, useRef, useState } from "react"
+import type { EventItem } from "../components/WeekGrid"
+import { parseEventItems } from "../lib/storage"
+import type { TransferState } from "../components/TransferToast"
+
+function buildExportFilename() {
+    const stamp = new Date().toISOString().slice(0, 10)
+    return `timebox-events-${stamp}.json`
+}
+
+function downloadJson(items: EventItem[]) {
+    const blob = new Blob([JSON.stringify(items, null, 2)], {
+        type: "application/json",
+    })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement("a")
+    anchor.href = url
+    anchor.download = buildExportFilename()
+    anchor.click()
+    URL.revokeObjectURL(url)
+}
+
+export function useJsonTransfer({
+    items,
+    setItems,
+    onImportSuccess,
+}: {
+    items: EventItem[]
+    setItems: Dispatch<SetStateAction<EventItem[]>>
+    onImportSuccess: () => void
+}) {
+    const importInputRef = useRef<HTMLInputElement | null>(null)
+    const [transferMessage, setTransferMessage] = useState<string | null>(null)
+    const [transferState, setTransferState] = useState<TransferState>(null)
+
+    const exportJson = () => {
+        downloadJson(items)
+        setTransferMessage(`Exported ${items.length} event${items.length === 1 ? "" : "s"} to JSON.`)
+        setTransferState("success")
+    }
+
+    const importJson = async (event: ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0]
+        if (!file) return
+
+        try {
+            const raw = await file.text()
+            const parsed = parseEventItems(raw)
+
+            if (!parsed) {
+                setTransferMessage("Import failed. The JSON file is invalid or missing required fields.")
+                setTransferState("error")
+                return
+            }
+
+            setItems(parsed)
+            onImportSuccess()
+            setTransferMessage(`Imported ${parsed.length} event${parsed.length === 1 ? "" : "s"} from ${file.name}.`)
+            setTransferState("success")
+        } catch {
+            setTransferMessage("Import failed. The file could not be read.")
+            setTransferState("error")
+        } finally {
+            event.target.value = ""
+        }
+    }
+
+    const openImportPicker = () => importInputRef.current?.click()
+
+    return {
+        importInputRef,
+        transferMessage,
+        transferState,
+        exportJson,
+        importJson,
+        openImportPicker,
+    }
+}

--- a/hooks/useSwipeNavigation.ts
+++ b/hooks/useSwipeNavigation.ts
@@ -1,0 +1,180 @@
+"use client"
+
+import { useRef, type PointerEvent as ReactPointerEvent } from "react"
+import {
+    DAY_WIDTH_ZOOM_STEP,
+    MAX_DAY_WIDTH_ZOOM,
+    MAX_ZOOM,
+    MIN_DAY_WIDTH_ZOOM,
+    MIN_ZOOM,
+    ZOOM_STEP,
+} from "./useViewOptions"
+
+const SWIPE_MIN_X = 64
+const SWIPE_MAX_TAP_MS = 700
+const SWIPE_VERTICAL_CANCEL_Y = 32
+const SWIPE_HORIZONTAL_RATIO = 1.4
+const SWIPE_EXCLUDED_TARGETS = 'button, input, textarea, select, a, [data-eventblock="1"]'
+const PINCH_MIN_DISTANCE = 40
+
+type SwipeStart = {
+    pointerId: number
+    pointerType: string
+    x: number
+    y: number
+    time: number
+    cancelled: boolean
+}
+
+type TouchPoint = {
+    x: number
+    y: number
+}
+
+type PinchStart = {
+    distance: number
+    zoom: number
+    dayWidthZoom: number
+}
+
+function clamp(value: number, min: number, max: number) {
+    return Math.min(max, Math.max(min, value))
+}
+
+function snapToStep(value: number, step: number) {
+    return Math.round(value / step) * step
+}
+
+function getPinchDistance(points: TouchPoint[]) {
+    if (points.length < 2) return 0
+    return Math.hypot(points[0].x - points[1].x, points[0].y - points[1].y)
+}
+
+export function useSwipeNavigation({
+    zoom,
+    dayWidthZoom,
+    setZoom,
+    setDayWidthZoom,
+    onMoveDate,
+}: {
+    zoom: number
+    dayWidthZoom: number
+    setZoom: (next: number) => void
+    setDayWidthZoom: (next: number) => void
+    onMoveDate: (direction: -1 | 1) => void
+}) {
+    const swipeStartRef = useRef<SwipeStart | null>(null)
+    const activeTouchPointsRef = useRef<Map<number, TouchPoint>>(new Map())
+    const pinchStartRef = useRef<PinchStart | null>(null)
+
+    const beginPinch = () => {
+        const distance = getPinchDistance([...activeTouchPointsRef.current.values()])
+        if (distance < PINCH_MIN_DISTANCE) return
+
+        pinchStartRef.current = {
+            distance,
+            zoom,
+            dayWidthZoom,
+        }
+    }
+
+    const updatePinch = () => {
+        const pinchStart = pinchStartRef.current
+        if (!pinchStart) return
+
+        const distance = getPinchDistance([...activeTouchPointsRef.current.values()])
+        if (distance < PINCH_MIN_DISTANCE) return
+
+        const scale = distance / pinchStart.distance
+        setZoom(clamp(snapToStep(pinchStart.zoom * scale, ZOOM_STEP), MIN_ZOOM, MAX_ZOOM))
+        setDayWidthZoom(
+            clamp(
+                snapToStep(pinchStart.dayWidthZoom * scale, DAY_WIDTH_ZOOM_STEP),
+                MIN_DAY_WIDTH_ZOOM,
+                MAX_DAY_WIDTH_ZOOM
+            )
+        )
+    }
+
+    const startSwipe = (event: ReactPointerEvent<HTMLDivElement>) => {
+        if (event.pointerType === "touch") {
+            activeTouchPointsRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY })
+            if (activeTouchPointsRef.current.size >= 2) {
+                swipeStartRef.current = null
+                beginPinch()
+                return
+            }
+        }
+
+        if (event.pointerType === "mouse" && event.button !== 0) return
+        if (event.pointerType !== "touch" && event.pointerType !== "mouse") return
+
+        const target = event.target as HTMLElement | null
+        if (target?.closest(SWIPE_EXCLUDED_TARGETS)) return
+
+        swipeStartRef.current = {
+            pointerId: event.pointerId,
+            pointerType: event.pointerType,
+            x: event.clientX,
+            y: event.clientY,
+            time: performance.now(),
+            cancelled: false,
+        }
+    }
+
+    const trackSwipe = (event: ReactPointerEvent<HTMLDivElement>) => {
+        if (event.pointerType === "touch" && activeTouchPointsRef.current.has(event.pointerId)) {
+            activeTouchPointsRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY })
+            if (pinchStartRef.current) {
+                updatePinch()
+                return
+            }
+        }
+
+        const start = swipeStartRef.current
+        if (!start || event.pointerId !== start.pointerId || event.pointerType !== start.pointerType) return
+        if (event.pointerType === "mouse" && event.buttons !== 1) return
+
+        const dx = event.clientX - start.x
+        const dy = event.clientY - start.y
+        const horizontalIntent = Math.abs(dx) >= Math.abs(dy) * SWIPE_HORIZONTAL_RATIO
+        const verticalIntent = Math.abs(dy) > SWIPE_VERTICAL_CANCEL_Y && !horizontalIntent
+        if (verticalIntent) start.cancelled = true
+    }
+
+    const finishSwipe = (event: ReactPointerEvent<HTMLDivElement>) => {
+        if (event.pointerType === "touch") {
+            activeTouchPointsRef.current.delete(event.pointerId)
+            if (pinchStartRef.current) {
+                if (activeTouchPointsRef.current.size < 2) pinchStartRef.current = null
+                swipeStartRef.current = null
+                return
+            }
+        }
+
+        const start = swipeStartRef.current
+        swipeStartRef.current = null
+        if (!start || start.cancelled || event.pointerId !== start.pointerId || event.pointerType !== start.pointerType) return
+
+        const dx = event.clientX - start.x
+        const dy = event.clientY - start.y
+        const elapsed = performance.now() - start.time
+        if (elapsed > SWIPE_MAX_TAP_MS) return
+        if (Math.abs(dx) < SWIPE_MIN_X || Math.abs(dx) < Math.abs(dy) * SWIPE_HORIZONTAL_RATIO) return
+
+        onMoveDate(dx < 0 ? 1 : -1)
+    }
+
+    const cancelSwipe = (event: ReactPointerEvent<HTMLDivElement>) => {
+        activeTouchPointsRef.current.delete(event.pointerId)
+        if (activeTouchPointsRef.current.size < 2) pinchStartRef.current = null
+        swipeStartRef.current = null
+    }
+
+    return {
+        startSwipe,
+        trackSwipe,
+        finishSwipe,
+        cancelSwipe,
+    }
+}

--- a/hooks/useViewOptions.ts
+++ b/hooks/useViewOptions.ts
@@ -1,26 +1,24 @@
 "use client"
 
 import { useEffect, useMemo, useState } from "react"
-import { addDays, getTodayDateKey, isDateKey } from "../lib/date"
+import { addDays, getTodayDateKey } from "../lib/date"
+import {
+    clamp,
+    DAY_WIDTH_ZOOM_STEP,
+    MAX_DAY_WIDTH_ZOOM,
+    MAX_START_HOUR,
+    MAX_ZOOM,
+    MIN_DAY_WIDTH_ZOOM,
+    MIN_START_HOUR,
+    MIN_ZOOM,
+    parseStoredViewOptions,
+    ZOOM_STEP,
+} from "../lib/viewOptions"
 
 const VISIBLE_DAY_COUNT = 31
 const VIEW_OPTIONS_STORAGE_KEY = "timeboxing-tool:v1:view-options"
-const MIN_START_HOUR = 0
-const MAX_START_HOUR = 12
-export const MIN_ZOOM = 75
-export const MAX_ZOOM = 200
-export const ZOOM_STEP = 5
-export const MIN_DAY_WIDTH_ZOOM = 70
-export const MAX_DAY_WIDTH_ZOOM = 180
-export const DAY_WIDTH_ZOOM_STEP = 10
+export { DAY_WIDTH_ZOOM_STEP, MAX_DAY_WIDTH_ZOOM, MAX_ZOOM, MIN_DAY_WIDTH_ZOOM, MIN_ZOOM, ZOOM_STEP }
 const BASE_DAY_COLUMN_WIDTH = 112
-
-type StoredViewOptions = {
-    startHour?: unknown
-    zoom?: unknown
-    dayWidthZoom?: unknown
-    centerDateKey?: unknown
-}
 
 export function useViewOptions() {
     const [startHour, setStartHour] = useState(6)
@@ -100,35 +98,4 @@ export function useViewOptions() {
         viewEndMin,
         visibleDateKeys,
     }
-}
-
-function parseStoredViewOptions(raw: string | null) {
-    if (!raw) return null
-
-    try {
-        const parsed = JSON.parse(raw) as StoredViewOptions
-        if (!parsed || typeof parsed !== "object") return null
-
-        return {
-            startHour:
-                typeof parsed.startHour === "number" && Number.isFinite(parsed.startHour)
-                    ? clamp(parsed.startHour, MIN_START_HOUR, MAX_START_HOUR)
-                    : undefined,
-            zoom:
-                typeof parsed.zoom === "number" && Number.isFinite(parsed.zoom)
-                    ? clamp(parsed.zoom, MIN_ZOOM, MAX_ZOOM)
-                    : undefined,
-            dayWidthZoom:
-                typeof parsed.dayWidthZoom === "number" && Number.isFinite(parsed.dayWidthZoom)
-                    ? clamp(parsed.dayWidthZoom, MIN_DAY_WIDTH_ZOOM, MAX_DAY_WIDTH_ZOOM)
-                    : undefined,
-            centerDateKey: isDateKey(parsed.centerDateKey) ? parsed.centerDateKey : undefined,
-        }
-    } catch {
-        return null
-    }
-}
-
-function clamp(value: number, min: number, max: number) {
-    return Math.min(max, Math.max(min, value))
 }

--- a/lib/alarmSchedule.ts
+++ b/lib/alarmSchedule.ts
@@ -1,0 +1,36 @@
+import { toDateKey } from "./date"
+
+export type AlarmEvent = {
+    id: string
+    dateKey: string
+    startMin: number
+    endMin: number
+    label: string
+}
+
+export type ScheduledAlarmEvent = AlarmEvent & {
+    alarmMin: number
+    targetMs: number
+    fireKey: string
+}
+
+export function getTodaySchedule(items: AlarmEvent[], leadMin: number, nowMs: number): ScheduledAlarmEvent[] {
+    const now = new Date(nowMs)
+    const todayKey = toDateKey(now)
+    const startOfToday = new Date(now)
+    startOfToday.setHours(0, 0, 0, 0)
+
+    return items
+        .filter((x) => x.dateKey === todayKey)
+        .map((x) => {
+            const alarmMin = Math.max(0, x.startMin - leadMin)
+            return {
+                ...x,
+                alarmMin,
+                targetMs: startOfToday.getTime() + alarmMin * 60_000,
+                fireKey: `${todayKey}:${x.id}:${alarmMin}:${x.startMin}:${x.endMin}`,
+            }
+        })
+        .filter((x) => x.alarmMin >= 0 && x.alarmMin <= 1440)
+        .sort((a, b) => a.targetMs - b.targetMs)
+}

--- a/lib/viewOptions.ts
+++ b/lib/viewOptions.ts
@@ -1,0 +1,48 @@
+import { isDateKey } from "./date"
+
+export const MIN_START_HOUR = 0
+export const MAX_START_HOUR = 12
+export const MIN_ZOOM = 75
+export const MAX_ZOOM = 200
+export const ZOOM_STEP = 5
+export const MIN_DAY_WIDTH_ZOOM = 70
+export const MAX_DAY_WIDTH_ZOOM = 180
+export const DAY_WIDTH_ZOOM_STEP = 10
+
+type StoredViewOptions = {
+    startHour?: unknown
+    zoom?: unknown
+    dayWidthZoom?: unknown
+    centerDateKey?: unknown
+}
+
+export function parseStoredViewOptions(raw: string | null) {
+    if (!raw) return null
+
+    try {
+        const parsed = JSON.parse(raw) as StoredViewOptions
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null
+
+        return {
+            startHour:
+                typeof parsed.startHour === "number" && Number.isFinite(parsed.startHour)
+                    ? clamp(parsed.startHour, MIN_START_HOUR, MAX_START_HOUR)
+                    : undefined,
+            zoom:
+                typeof parsed.zoom === "number" && Number.isFinite(parsed.zoom)
+                    ? clamp(parsed.zoom, MIN_ZOOM, MAX_ZOOM)
+                    : undefined,
+            dayWidthZoom:
+                typeof parsed.dayWidthZoom === "number" && Number.isFinite(parsed.dayWidthZoom)
+                    ? clamp(parsed.dayWidthZoom, MIN_DAY_WIDTH_ZOOM, MAX_DAY_WIDTH_ZOOM)
+                    : undefined,
+            centerDateKey: isDateKey(parsed.centerDateKey) ? parsed.centerDateKey : undefined,
+        }
+    } catch {
+        return null
+    }
+}
+
+export function clamp(value: number, min: number, max: number) {
+    return Math.min(max, Math.max(min, value))
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "test": "tsc -p tsconfig.test.json && node --test \".test-out/tests/**/*.test.js\"",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"

--- a/tests/alarm.test.ts
+++ b/tests/alarm.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { getTodaySchedule, type AlarmEvent } from "../lib/alarmSchedule"
+
+test("today schedule includes only today's alarms ordered by target time", () => {
+    const nowMs = new Date(2026, 4, 19, 8, 0).getTime()
+    const schedule = getTodaySchedule(
+        [
+            event("later", "2026-05-19", 10 * 60),
+            event("other-day", "2026-05-20", 9 * 60),
+            event("earlier", "2026-05-19", 9 * 60),
+        ],
+        10,
+        nowMs
+    )
+
+    assert.deepEqual(
+        schedule.map((ev) => ev.id),
+        ["earlier", "later"]
+    )
+    assert.equal(schedule[0].alarmMin, 8 * 60 + 50)
+    assert.equal(schedule[0].fireKey, "2026-05-19:earlier:530:540:570")
+})
+
+test("alarm lead time does not schedule before the start of day", () => {
+    const nowMs = new Date(2026, 4, 19, 0, 0).getTime()
+    const schedule = getTodaySchedule([event("early", "2026-05-19", 5)], 10, nowMs)
+
+    assert.equal(schedule[0].alarmMin, 0)
+    assert.equal(schedule[0].targetMs, new Date(2026, 4, 19, 0, 0).getTime())
+})
+
+function event(id: string, dateKey: string, startMin: number): AlarmEvent {
+    return {
+        id,
+        dateKey,
+        startMin,
+        endMin: startMin + 30,
+        label: id,
+    }
+}

--- a/tests/date.test.ts
+++ b/tests/date.test.ts
@@ -1,0 +1,37 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import {
+    addDays,
+    formatDateHeader,
+    getDateKeyForLegacyDayIndex,
+    getDayName,
+    getWeekStartDateKey,
+    isDateKey,
+    parseDateKey,
+    toDateKey,
+} from "../lib/date"
+
+test("date keys round-trip with local calendar dates", () => {
+    const date = new Date(2026, 4, 19)
+
+    assert.equal(toDateKey(date), "2026-05-19")
+    assert.equal(toDateKey(parseDateKey("2026-05-19")), "2026-05-19")
+})
+
+test("date key validation rejects impossible dates", () => {
+    assert.equal(isDateKey("2026-02-28"), true)
+    assert.equal(isDateKey("2026-02-30"), false)
+    assert.equal(isDateKey("2026-2-3"), false)
+    assert.equal(isDateKey("not-a-date"), false)
+})
+
+test("week helpers use Monday as the first day", () => {
+    assert.equal(getWeekStartDateKey("2026-05-24"), "2026-05-18")
+    assert.equal(getDateKeyForLegacyDayIndex(2, new Date(2026, 4, 24)), "2026-05-20")
+})
+
+test("day and header formatting are stable", () => {
+    assert.equal(addDays("2026-05-31", 1), "2026-06-01")
+    assert.equal(getDayName("2026-05-19"), "Tue")
+    assert.equal(formatDateHeader("2026-05-19"), "Tue 5/19")
+})

--- a/tests/layout.test.ts
+++ b/tests/layout.test.ts
@@ -1,0 +1,48 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { computeOverlapLayout } from "../components/week/layout"
+
+test("non-overlapping events share one lane", () => {
+    const layout = computeOverlapLayout([
+        event("a", 9 * 60, 10 * 60),
+        event("b", 10 * 60, 11 * 60),
+    ])
+
+    assert.deepEqual(layout.get("a"), { lane: 0, lanesCount: 1 })
+    assert.deepEqual(layout.get("b"), { lane: 0, lanesCount: 1 })
+})
+
+test("overlapping events are assigned stable lanes for the whole overlap group", () => {
+    const layout = computeOverlapLayout([
+        event("a", 9 * 60, 11 * 60),
+        event("b", 9 * 60 + 30, 10 * 60),
+        event("c", 10 * 60, 12 * 60),
+    ])
+
+    assert.deepEqual(layout.get("a"), { lane: 0, lanesCount: 2 })
+    assert.deepEqual(layout.get("b"), { lane: 1, lanesCount: 2 })
+    assert.deepEqual(layout.get("c"), { lane: 1, lanesCount: 2 })
+})
+
+test("separate overlap groups keep independent lane counts", () => {
+    const layout = computeOverlapLayout([
+        event("a", 8 * 60, 9 * 60),
+        event("b", 8 * 60 + 15, 8 * 60 + 45),
+        event("c", 10 * 60, 11 * 60),
+    ])
+
+    assert.equal(layout.get("a")?.lanesCount, 2)
+    assert.equal(layout.get("b")?.lanesCount, 2)
+    assert.deepEqual(layout.get("c"), { lane: 0, lanesCount: 1 })
+})
+
+function event(id: string, startMin: number, endMin: number) {
+    return {
+        id,
+        dateKey: "2026-05-19",
+        startMin,
+        endMin,
+        label: id,
+        color: "#2563eb",
+    }
+}

--- a/tests/view-options.test.ts
+++ b/tests/view-options.test.ts
@@ -1,0 +1,47 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { parseStoredViewOptions } from "../lib/viewOptions"
+
+test("stored view options are restored when valid", () => {
+    assert.deepEqual(
+        parseStoredViewOptions(
+            JSON.stringify({
+                startHour: 8,
+                zoom: 125,
+                dayWidthZoom: 120,
+                centerDateKey: "2026-05-19",
+            })
+        ),
+        {
+            startHour: 8,
+            zoom: 125,
+            dayWidthZoom: 120,
+            centerDateKey: "2026-05-19",
+        }
+    )
+})
+
+test("stored view options clamp numeric values and ignore invalid dates", () => {
+    assert.deepEqual(
+        parseStoredViewOptions(
+            JSON.stringify({
+                startHour: 99,
+                zoom: 10,
+                dayWidthZoom: 999,
+                centerDateKey: "2026-02-30",
+            })
+        ),
+        {
+            startHour: 12,
+            zoom: 75,
+            dayWidthZoom: 180,
+            centerDateKey: undefined,
+        }
+    )
+})
+
+test("stored view options ignore invalid payloads", () => {
+    assert.equal(parseStoredViewOptions(null), null)
+    assert.equal(parseStoredViewOptions("broken json"), null)
+    assert.equal(parseStoredViewOptions("[]"), null)
+})

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "incremental": false,
+    "isolatedModules": false,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmit": false,
+    "outDir": ".test-out",
+    "target": "ES2022",
+    "types": ["node"]
+  },
+  "include": [
+    "components/week/layout.ts",
+    "hooks/useAlarm.ts",
+    "hooks/useViewOptions.ts",
+    "lib/**/*.ts",
+    "tests/**/*.ts"
+  ],
+  "exclude": ["node_modules", ".next", ".test-out"]
+}


### PR DESCRIPTION
## Summary
- add a lightweight `npm test` flow using `node:test`
- extract alarm schedule and view option parsing logic into testable pure modules
- cover alarm scheduling, date helpers, overlap layout, and persisted view option parsing

## Verification
- `npm test`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`