### PR TITLE
ローカル生成物の扱いを整理する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+/dev-server.log
 
 # env files (can opt-in for committing if needed)
 .env*

--- a/docs/issue-logs/README.md
+++ b/docs/issue-logs/README.md
@@ -28,6 +28,7 @@ Each log should capture:
 - [Issue #34: Persist View Options](./issue-34-persist-view-options.md)
 - [Issue #36: Alarm Status and Test Controls](./issue-36-alarm-status-and-test-controls.md)
 - [Issue #38: Overlap Layout for Three or More Events](./issue-38-overlap-layout.md)
+- [Issue #43: Local Artifact Handling](./issue-43-local-artifacts.md)
 
 ## Japanese
 

--- a/docs/issue-logs/README.md
+++ b/docs/issue-logs/README.md
@@ -28,7 +28,7 @@ Each log should capture:
 - [Issue #34: Persist View Options](./issue-34-persist-view-options.md)
 - [Issue #36: Alarm Status and Test Controls](./issue-36-alarm-status-and-test-controls.md)
 - [Issue #38: Overlap Layout for Three or More Events](./issue-38-overlap-layout.md)
-- [Issue #43: Local Artifact Handling](./issue-43-local-artifacts.md)
+- [Issue #43: ローカル生成物の扱い整理](./issue-43-local-artifacts.md)
 
 ## Japanese
 

--- a/docs/issue-logs/issue-43-local-artifacts.md
+++ b/docs/issue-logs/issue-43-local-artifacts.md
@@ -1,0 +1,20 @@
+# Issue #43: Local Artifact Handling
+
+## Symptom
+
+Local files such as `dev-server.log` and `docs/learning/` could remain untracked in the working tree, making it easy to accidentally mix local artifacts into a PR.
+
+## Root Cause
+
+The repository did not clearly distinguish temporary local output from documentation that should be versioned. `dev-server.log` was not ignored, and `docs/learning/` had no local policy or index explaining why it should be tracked.
+
+## Fix
+
+- Added `/dev-server.log` to `.gitignore` as a local development log.
+- Kept `docs/learning/` as repository-managed documentation.
+- Added `docs/learning/README.md` to explain what belongs in the learning docs directory.
+- Added this issue log so the artifact policy decision is visible from the issue-log index.
+
+## Verification
+
+- `npm run lint`

--- a/docs/issue-logs/issue-43-local-artifacts.md
+++ b/docs/issue-logs/issue-43-local-artifacts.md
@@ -1,20 +1,20 @@
-# Issue #43: Local Artifact Handling
+# Issue #43: ローカル生成物の扱い整理
 
-## Symptom
+## 症状
 
-Local files such as `dev-server.log` and `docs/learning/` could remain untracked in the working tree, making it easy to accidentally mix local artifacts into a PR.
+`dev-server.log` や `docs/learning/` のようなローカルファイルが未追跡のまま作業ツリーに残り、PR 作成時にローカル生成物を誤って混入させやすい状態だった。
 
-## Root Cause
+## 原因
 
-The repository did not clearly distinguish temporary local output from documentation that should be versioned. `dev-server.log` was not ignored, and `docs/learning/` had no local policy or index explaining why it should be tracked.
+一時的なローカル出力と、リポジトリで管理すべきドキュメントの区別が明確になっていなかった。`dev-server.log` は ignore されておらず、`docs/learning/` には管理対象である理由を示す README もなかった。
 
-## Fix
+## 修正
 
-- Added `/dev-server.log` to `.gitignore` as a local development log.
-- Kept `docs/learning/` as repository-managed documentation.
-- Added `docs/learning/README.md` to explain what belongs in the learning docs directory.
-- Added this issue log so the artifact policy decision is visible from the issue-log index.
+- ローカル開発ログとして `/dev-server.log` を `.gitignore` に追加した。
+- `docs/learning/` はリポジトリ管理対象の学習用ドキュメントとして扱う方針にした。
+- `docs/learning/README.md` を追加し、このディレクトリに置く内容を説明した。
+- 判断の経緯が issue log の索引から追えるように、この実装ログを追加した。
 
-## Verification
+## 検証
 
 - `npm run lint`

--- a/docs/learning/README.md
+++ b/docs/learning/README.md
@@ -1,0 +1,14 @@
+# Learning Docs
+
+このディレクトリには、Timebox の実装を理解するための学習用ドキュメントを保存します。
+
+## Documents
+
+- [Timebox 技術理解ガイド](./timebox-technical-guide-ja.txt)
+- [Timebox 技術理解 問題集](./timebox-practice-questions-ja.txt)
+
+## 管理方針
+
+- アプリの実装理解やオンボーディングに役立つ資料は、このディレクトリで管理します。
+- ローカル開発時の一時ログや実行結果は含めません。
+- 内容を更新した場合は、関連する実装変更や issue と対応が分かるようにします。

--- a/docs/learning/README.md
+++ b/docs/learning/README.md
@@ -1,8 +1,8 @@
-# Learning Docs
+# 学習用ドキュメント
 
 このディレクトリには、Timebox の実装を理解するための学習用ドキュメントを保存します。
 
-## Documents
+## ドキュメント
 
 - [Timebox 技術理解ガイド](./timebox-technical-guide-ja.txt)
 - [Timebox 技術理解 問題集](./timebox-practice-questions-ja.txt)

--- a/docs/learning/timebox-practice-questions-ja.txt
+++ b/docs/learning/timebox-practice-questions-ja.txt
@@ -1,0 +1,481 @@
+Timebox 技術理解 問題集
+=======================
+
+この問題集は、Timebox のコードを読みながら理解するためのものです。
+答えを暗記するより、該当ファイルを開いて「なぜそうなるか」を確認してください。
+
+
+第1章: リポジトリと技術スタック
+------------------------------
+
+Q1. package.json を開いてください。
+このアプリを開発モードで起動するコマンドは何ですか。
+
+答え:
+npm run dev
+
+
+Q2. package.json を見てください。
+このアプリで使っている主な UI ライブラリは何ですか。
+
+答え:
+React です。
+Next.js は React を使うためのフレームワークです。
+
+
+Q3. package.json を見てください。
+TypeScript は dependencies と devDependencies のどちらに入っていますか。
+
+答え:
+devDependencies です。
+TypeScript は開発時の型チェックやビルドに使われるためです。
+
+
+Q4. app/page.tsx の先頭にある "use client" は何のためですか。
+
+答え:
+このファイルをブラウザ側で動く Client Component にするためです。
+useState、useEffect、localStorage、window などを使うために必要です。
+
+
+第2章: データ構造
+----------------
+
+Q5. EventItem 型はどのファイルで定義されていますか。
+
+答え:
+components/WeekGrid.tsx です。
+
+
+Q6. EventItem の dateKey はどのような形式の文字列ですか。
+
+答え:
+"YYYY-MM-DD" 形式です。
+例: "2026-05-05"
+
+
+Q7. startMin が 570 のとき、これは何時何分を表しますか。
+
+答え:
+9:30 です。
+570 = 9 * 60 + 30 です。
+
+
+Q8. 13:15 を startMin として表すと何になりますか。
+
+答え:
+795 です。
+13 * 60 + 15 = 795 です。
+
+
+Q9. 9:00 から 10:30 の予定を EventItem で表すとき、startMin と endMin は何になりますか。
+
+答え:
+startMin は 540、endMin は 630 です。
+
+
+Q10. label、description、urls の役割をそれぞれ説明してください。
+
+答え:
+label は予定タイトルです。
+description は予定メモです。
+urls は予定に紐づく URL の配列です。
+
+
+第3章: 画面の親子関係
+--------------------
+
+Q11. app/page.tsx の Home コンポーネントは、予定一覧をどの変数名で持っていますか。
+
+答え:
+items です。
+
+
+Q12. Home から予定一覧を受け取り、日付ごとの表示を作るコンポーネントは何ですか。
+
+答え:
+WeekGrid です。
+
+
+Q13. 1日分の列を担当するコンポーネントは何ですか。
+
+答え:
+DayColumn です。
+
+
+Q14. 1つの予定ブロックを担当するコンポーネントは何ですか。
+
+答え:
+EventBlock です。
+
+
+Q15. 次の親子関係を埋めてください。
+
+Home
+  -> ________
+      -> ________
+          -> ________
+
+答え:
+Home
+  -> WeekGrid
+      -> DayColumn
+          -> EventBlock
+
+
+第4章: 表示計算
+--------------
+
+Q16. EventBlock.tsx で、予定ブロックの上からの位置を表す変数名は何ですか。
+
+答え:
+top です。
+
+
+Q17. EventBlock.tsx で、予定ブロックの高さを表す変数名は何ですか。
+
+答え:
+height です。
+
+
+Q18. viewStartMin が 360、item.startMin が 540、pxPerMin が 1 のとき、top は何 px ですか。
+
+答え:
+180px です。
+(540 - 360) * 1 = 180 です。
+
+
+Q19. 予定が 9:00 から 10:00、pxPerMin が 1 のとき、height は何 px ですか。
+
+答え:
+60px です。
+
+
+Q20. pxPerMin が 2 のとき、60分の予定の height は何 px ですか。
+
+答え:
+120px です。
+60 * 2 = 120 です。
+
+
+第5章: 15分単位の丸め
+--------------------
+
+Q21. lib/time.ts にある snap 関数は何をしますか。
+
+答え:
+分数を指定された単位に丸めます。
+このアプリでは主に 15分単位にそろえるために使います。
+
+
+Q22. snap(62, 15) はいくつになりますか。
+
+答え:
+60 です。
+
+
+Q23. snap(68, 15) はいくつになりますか。
+
+答え:
+75 です。
+
+
+Q24. DayColumn.tsx で、空き時間をダブルクリックしたときに開始時刻を 15分単位へ丸める処理はどこにありますか。
+
+答え:
+addEventAtClientY 内の snap(rawMin, gridMin) です。
+
+
+Q25. EventBlock.tsx で、ドラッグ移動時に開始時刻を丸めている処理はどこにありますか。
+
+答え:
+onPointerDown 内の move 関数で、snap(rawStart, gridMin) を使っています。
+
+
+第6章: 保存と読み込み
+--------------------
+
+Q26. 予定を localStorage に保存する hook は何ですか。
+
+答え:
+useTimeboxingItems です。
+
+
+Q27. useTimeboxingItems.ts で、保存済みデータを読み込むために使っているブラウザ API は何ですか。
+
+答え:
+localStorage.getItem です。
+
+
+Q28. useTimeboxingItems.ts で、予定データを保存するために使っているブラウザ API は何ですか。
+
+答え:
+localStorage.setItem です。
+
+
+Q29. localStorage から読んだ JSON が正しいか確認する関数は何ですか。
+
+答え:
+parseEventItems です。
+
+
+Q30. parseEventItems はどのファイルにありますか。
+
+答え:
+lib/storage.ts です。
+
+
+第7章: JSON インポート、エクスポート
+----------------------------------
+
+Q31. app/page.tsx で JSON エクスポートのファイル名を作る関数は何ですか。
+
+答え:
+buildExportFilename です。
+
+
+Q32. JSON エクスポートでは、items をどの関数で文字列にしていますか。
+
+答え:
+JSON.stringify です。
+
+
+Q33. インポート時に、ファイルの中身を読むために使っているメソッドは何ですか。
+
+答え:
+file.text() です。
+
+
+Q34. インポートした JSON が不正なとき、画面には成功とエラーのどちらの状態が設定されますか。
+
+答え:
+エラーです。
+transferState に "error" が設定されます。
+
+
+第8章: 日付
+----------
+
+Q35. lib/date.ts の toDateKey は何をする関数ですか。
+
+答え:
+Date オブジェクトを "YYYY-MM-DD" 形式の文字列に変換します。
+
+
+Q36. lib/date.ts の parseDateKey は何をする関数ですか。
+
+答え:
+"YYYY-MM-DD" 形式の文字列を Date オブジェクトに変換します。
+
+
+Q37. addDays("2026-05-05", 1) は何を返す想定ですか。
+
+答え:
+"2026-05-06" です。
+
+
+Q38. useViewOptions.ts の visibleDateKeys は何日分の日付を作りますか。
+
+答え:
+31日分です。
+VISIBLE_DAY_COUNT が 31 です。
+
+
+第9章: アラーム
+--------------
+
+Q39. アラーム機能を担当する hook は何ですか。
+
+答え:
+useAlarm です。
+
+
+Q40. 通知を出すために使っているブラウザ API は何ですか。
+
+答え:
+Notification です。
+
+
+Q41. ビープ音を鳴らすために使っているブラウザ API は何ですか。
+
+答え:
+AudioContext です。
+
+
+Q42. 10:00 開始の予定で leadMin が 5 の場合、アラームは何時何分に鳴りますか。
+
+答え:
+9:55 です。
+
+
+第10章: コード変更の練習
+-----------------------
+
+Q43. 新規予定のデフォルト時間を 30分から 45分に変えるには、どのファイルのどの定数を変えますか。
+
+答え:
+app/page.tsx の DEFAULT_DURATION を 30 から 45 に変えます。
+
+
+Q44. 表示開始時刻の初期値を 6時から 7時に変えるには、どのファイルのどの state 初期値を変えますか。
+
+答え:
+hooks/useViewOptions.ts の useState(6) を useState(7) に変えます。
+
+
+Q45. 1分あたりのピクセル数の基本値を変えるには、どのファイルのどの値を見ればよいですか。
+
+答え:
+hooks/useViewOptions.ts の pxPerMin = 0.96 * (zoom / 100) を見ます。
+
+
+Q46. EventItem に color を追加したい場合、最低限どのあたりを確認する必要がありますか。
+
+答え:
+components/WeekGrid.tsx の EventItem 型、
+lib/storage.ts の sanitizeEventItem、
+予定詳細編集コンポーネント、
+components/week/EventBlock.tsx の表示処理を確認します。
+
+
+Q47. URL リンクの表示ラベルを "Link" から "Open" に変えたい場合、どのファイルを見ますか。
+
+答え:
+components/week/EventBlock.tsx です。
+
+
+Q48. 今日の日付列の背景色を変えたい場合、どのファイルを見ますか。
+
+答え:
+components/week/DayColumn.tsx の getColumnClass と、
+components/WeekGrid.tsx の getHeaderClass を見ます。
+
+
+第11章: 自力で考える問題
+----------------------
+
+Q49. なぜ startMin と endMin を "09:00" の文字列ではなく number で持っているのでしょうか。
+
+解答例:
+ドラッグ量や表示位置を計算しやすいからです。
+分数なら足し算、引き算、丸め処理が簡単です。
+
+
+Q50. なぜ localStorage に保存する前に JSON.stringify が必要なのでしょうか。
+
+解答例:
+localStorage は文字列しか保存できないためです。
+配列やオブジェクトを保存するには JSON 文字列に変換する必要があります。
+
+
+Q51. なぜ JSON インポート時に parseEventItems で検証する必要があるのでしょうか。
+
+解答例:
+壊れたファイルや想定外のデータをそのまま使うと、画面表示や計算が壊れる可能性があるからです。
+
+
+Q52. なぜ WeekGrid で items を日付ごとに分けてから DayColumn に渡しているのでしょうか。
+
+解答例:
+DayColumn は1日分の表示だけに集中できるからです。
+親の WeekGrid が日付分類を担当すると、子コンポーネントの役割が分かりやすくなります。
+
+
+Q53. なぜ EventBlock のドラッグ処理では pointermove と pointerup を window に登録しているのでしょうか。
+
+解答例:
+ドラッグ中にマウスや指が予定ブロックの外へ出ても、移動や終了を追跡できるようにするためです。
+
+
+Q54. なぜ Notification permission をユーザー操作で要求する必要があるのでしょうか。
+
+解答例:
+ブラウザの通知はユーザーの許可が必要だからです。
+勝手に通知を出せないようにブラウザが制限しています。
+
+
+第12章: ミニ課題
+----------------
+
+課題1.
+app/page.tsx を開いて DEFAULT_DURATION を探してください。
+この値がどこで WeekGrid に渡されているか確認してください。
+
+確認ポイント:
+DEFAULT_DURATION は defaultDurationMin として WeekGrid に渡されています。
+
+
+課題2.
+hooks/useViewOptions.ts を開いて、表示日数を 31日から 14日に変えるにはどこを変えるか探してください。
+
+確認ポイント:
+VISIBLE_DAY_COUNT を 31 から 14 に変えます。
+
+
+課題3.
+lib/time.ts の minToHHMM(75) が何を返すか考えてください。
+
+確認ポイント:
+"1:15" を返します。
+
+
+課題4.
+lib/storage.ts の isValidEventItem を読んでください。
+startMin が -1 の予定が不正になる理由を説明してください。
+
+確認ポイント:
+startMin < 0 の場合 false になるためです。
+
+
+課題5.
+EventBlock.tsx を読んでください。
+予定ブロックの最小表示高さはいくつですか。
+
+確認ポイント:
+18px です。
+Math.max(..., 18) が使われています。
+
+
+課題6.
+EventBlock.tsx を読んでください。
+http または https 以外の URL はリンクとして表示されますか。
+
+確認ポイント:
+表示されません。
+new URL で解析し、protocol が "http:" または "https:" のものだけを firstUrl としています。
+
+
+課題7.
+useAlarm.ts を読んでください。
+アラーム済みかどうかを記録している変数は何ですか。
+
+確認ポイント:
+firedRef です。
+Set<string> で fireKey を記録しています。
+
+
+課題8.
+app/page.tsx を読んでください。
+Escape キーを押したときに閉じる UI は何ですか。
+
+確認ポイント:
+settingsOpen と calendarOpen が false になります。
+つまり設定モーダルとカレンダーが閉じます。
+
+
+課題9.
+WeekGrid.tsx を読んでください。
+今日の現在時刻ラインが表示される条件を説明してください。
+
+確認ポイント:
+nowMin が null ではなく、viewStartMin 以上、viewEndMin 以下のときです。
+
+
+課題10.
+自分で小さな変更案を1つ考えてください。
+その変更には、どのファイルを触る必要があるかを書いてください。
+
+解答例:
+予定ブロックのリンク表示を "Link" から "Open" に変えたい。
+触るファイルは components/week/EventBlock.tsx。
+

--- a/docs/learning/timebox-technical-guide-ja.txt
+++ b/docs/learning/timebox-technical-guide-ja.txt
@@ -1,0 +1,465 @@
+Timebox 技術理解ガイド
+=======================
+
+このテキストは「Timebox の技術が何も分からない」状態から、リポジトリの中身を読めるようになるための説明です。
+プログラミング経験が浅くても追えるように、まず全体像を説明してから、ファイルごとの役割に進みます。
+
+
+1. Timebox は何をするアプリか
+----------------------------
+
+Timebox は、予定を時間の箱としてカレンダー上に並べる Web アプリです。
+
+主な操作は次の通りです。
+
+- 日付ごとの縦長タイムラインを見る
+- 空いている時間をダブルクリックして予定を追加する
+- 予定ブロックをドラッグして時刻や日付を変える
+- 予定ブロックの上下をドラッグして時間の長さを変える
+- 予定の詳細、メモ、URL を編集する
+- JSON で予定をインポート、エクスポートする
+- ブラウザ内の localStorage に予定を保存する
+- 今日の現在時刻ラインやアラームを表示、通知する
+
+このアプリはサーバーにログインしてデータを保存するタイプではありません。
+予定データはブラウザの localStorage に保存されます。
+
+
+2. 使っている主な技術
+--------------------
+
+package.json から見ると、このアプリは以下の技術で作られています。
+
+- Next.js
+  React を使った Web アプリのフレームワークです。
+  このリポジトリでは App Router 形式で、app/page.tsx が画面の中心です。
+
+- React
+  UI をコンポーネントという部品に分けて作るライブラリです。
+  WeekGrid、DayColumn、EventBlock などが React コンポーネントです。
+
+- TypeScript
+  JavaScript に型を付けた言語です。
+  EventItem のように、データの形を明示できます。
+
+- Tailwind CSS
+  className に短いクラス名を書いて見た目を作る CSS ツールです。
+  例: bg-white、text-gray-900、rounded-xl、border など。
+
+- localStorage
+  ブラウザに小さなデータを保存する仕組みです。
+  サーバーやデータベースなしで予定を保存するために使っています。
+
+- Browser APIs
+  Notification、AudioContext、Blob、URL.createObjectURL など、ブラウザに元からある機能を使っています。
+  通知、音、JSON ダウンロードなどに関係します。
+
+
+3. まず見るべきファイル
+----------------------
+
+最初は全部を読もうとしないでください。
+次の順番で読むと理解しやすいです。
+
+1. package.json
+   アプリの技術スタックと起動コマンドが分かります。
+
+2. app/page.tsx
+   アプリ全体の状態管理と画面の組み立てをしています。
+
+3. components/WeekGrid.tsx
+   日付列と時間軸を並べるメインのカレンダー表示です。
+
+4. components/week/DayColumn.tsx
+   1日分の列です。
+   空欄ダブルクリックで予定追加、時間目盛り、予定ブロック表示を担当します。
+
+5. components/week/EventBlock.tsx
+   1つの予定ブロックです。
+   ドラッグ移動、リサイズ、URL リンク表示を担当します。
+
+6. hooks/useTimeboxingItems.ts
+   予定データを React の state と localStorage に保存します。
+
+7. lib/storage.ts
+   JSON から読み込んだ予定データが正しい形かチェックします。
+
+8. lib/time.ts と lib/date.ts
+   時刻や日付の小さな便利関数です。
+
+
+4. データの中心: EventItem
+-------------------------
+
+予定データの基本形は components/WeekGrid.tsx にある EventItem です。
+
+EventItem の形:
+
+type EventItem = {
+    id: string
+    dateKey: string
+    startMin: number
+    endMin: number
+    label: string
+    urls?: string[]
+    description?: string
+}
+
+それぞれの意味:
+
+- id
+  予定を区別するための一意な文字列です。
+
+- dateKey
+  予定の日付です。
+  "2026-05-05" のような YYYY-MM-DD 形式です。
+
+- startMin
+  予定の開始時刻です。
+  0時から何分後かで表します。
+  例: 9:30 は 9 * 60 + 30 = 570 です。
+
+- endMin
+  予定の終了時刻です。
+  例: 10:00 は 600 です。
+
+- label
+  予定のタイトルです。
+
+- urls
+  予定に紐づく URL の配列です。
+
+- description
+  メモです。
+
+重要なのは、このアプリでは時刻を "09:30" の文字列ではなく、分数の number で扱っていることです。
+このおかげで、ドラッグ量から時刻を計算しやすくなります。
+
+
+5. app/page.tsx の役割
+---------------------
+
+app/page.tsx は Home コンポーネントを定義しています。
+このファイルはアプリの司令塔です。
+
+主な仕事:
+
+- useTimeboxingItems で予定データを読み書きする
+- useViewOptions で表示する日付範囲、拡大率、開始時刻を管理する
+- useNowMin で現在時刻を取得する
+- useAlarm でアラームを管理する
+- QuickAddModal、EventDetailsPopover、WeekGrid を表示する
+- JSON インポート、エクスポートを処理する
+- 設定モーダルやカレンダーポップアップを開閉する
+- スワイプやピンチ操作を処理する
+
+React では、画面に必要な値を state として持ちます。
+このアプリの代表的な state は次のようなものです。
+
+- items
+  予定一覧です。
+
+- settingsOpen
+  設定画面を開いているかどうかです。
+
+- calendarOpen
+  カレンダー選択を開いているかどうかです。
+
+- quickAdd
+  新規予定追加モーダルで編集中の値です。
+
+- selectedId
+  選択中の予定 ID です。
+
+
+6. 表示の流れ
+------------
+
+Timebox の画面表示は、おおまかに次の順番で流れます。
+
+1. app/page.tsx が予定データ items を持つ
+2. app/page.tsx が WeekGrid に items と表示条件を渡す
+3. WeekGrid が visibleDateKeys をもとに日付列を作る
+4. WeekGrid が予定を日付ごとに分ける
+5. WeekGrid が各日付に DayColumn を表示する
+6. DayColumn がその日の予定を EventBlock として表示する
+7. EventBlock が予定ブロックの位置と高さを計算する
+
+つまり、画面は次のような親子関係です。
+
+Home
+  -> WeekGrid
+      -> DayColumn
+          -> EventBlock
+
+
+7. 予定ブロックの位置計算
+------------------------
+
+EventBlock.tsx では、予定ブロックの縦位置と高さを計算しています。
+
+重要な値:
+
+- viewStartMin
+  表示開始時刻です。
+  例: 6:00 なら 360 です。
+
+- viewEndMin
+  表示終了時刻です。
+  このアプリでは 24:00、つまり 1440 です。
+
+- pxPerMin
+  1分を画面上で何ピクセルにするかです。
+  拡大率によって変わります。
+
+- item.startMin
+  予定の開始時刻です。
+
+- item.endMin
+  予定の終了時刻です。
+
+縦位置の考え方:
+
+top = (予定の開始分 - 表示開始分) * 1分あたりのピクセル
+
+例:
+
+- 表示開始が 6:00 なので viewStartMin = 360
+- 予定開始が 9:00 なので startMin = 540
+- pxPerMin = 1
+
+top = (540 - 360) * 1 = 180px
+
+高さの考え方:
+
+height = (予定の終了分 - 予定の開始分) * 1分あたりのピクセル
+
+例:
+
+- 予定が 9:00 から 10:00
+- 60分
+- pxPerMin = 1
+
+height = 60px
+
+
+8. 15分単位にそろえる仕組み
+--------------------------
+
+lib/time.ts に snap という関数があります。
+
+snap(min, grid) は、分数を grid に近い単位へ丸めます。
+
+例:
+
+- snap(62, 15) は 60
+- snap(68, 15) は 75
+- snap(30, 15) は 30
+
+このアプリでは gridMin が 15 なので、予定は 15分単位で追加、移動、リサイズされます。
+
+
+9. localStorage 保存の流れ
+-------------------------
+
+hooks/useTimeboxingItems.ts が保存を担当します。
+
+流れ:
+
+1. 初回表示時に localStorage.getItem(storageKey) で保存済みデータを読む
+2. parseEventItems でデータが正しいか確認する
+3. 正しければ items state に入れる
+4. items が変わったら localStorage.setItem で保存する
+
+注意点:
+
+- localStorage はブラウザ上にしかありません
+- そのため useTimeboxingItems.ts には "use client" が必要です
+- サーバー側では localStorage は使えません
+
+
+10. "use client" の意味
+----------------------
+
+Next.js では、ファイルの先頭に "use client" と書くと、そのコンポーネントはブラウザ側で動きます。
+
+このアプリでは以下のような処理が多いため、主要な UI ファイルに "use client" があります。
+
+- useState
+- useEffect
+- localStorage
+- window
+- document
+- PointerEvent
+- Notification
+- AudioContext
+
+これらはブラウザに依存するため、サーバー側ではそのまま使えません。
+
+
+11. JSON インポート、エクスポート
+-------------------------------
+
+エクスポートは app/page.tsx の downloadJson 関数で行います。
+
+流れ:
+
+1. items を JSON.stringify で文字列にする
+2. Blob を作る
+3. URL.createObjectURL で一時 URL を作る
+4. a 要素を作って click する
+5. JSON ファイルとしてダウンロードする
+
+インポートは handleImport で行います。
+
+流れ:
+
+1. ファイルを選ぶ
+2. file.text() で中身を読む
+3. parseEventItems で正しい予定配列か確認する
+4. 正しければ setItems(parsed) で予定一覧を置き換える
+
+lib/storage.ts は、壊れた JSON や不正な予定をそのまま使わないための安全装置です。
+
+
+12. アラームの仕組み
+------------------
+
+hooks/useAlarm.ts がアラームを担当します。
+
+使っているブラウザ機能:
+
+- Notification
+  デスクトップ通知を出すために使います。
+
+- AudioContext
+  ビープ音を鳴らすために使います。
+
+- setTimeout
+  次のアラーム時刻に合わせて処理を予約します。
+
+- setInterval
+  15秒ごとに現在時刻を確認します。
+
+アラームは予定の startMin と leadMin から鳴る時刻を計算します。
+
+例:
+
+- 予定開始: 10:00
+- leadMin: 5
+
+アラームは 9:55 に鳴ります。
+
+
+13. 日付の扱い
+-------------
+
+lib/date.ts では、日付を "YYYY-MM-DD" の dateKey として扱います。
+
+主な関数:
+
+- toDateKey(date)
+  Date を "YYYY-MM-DD" に変換します。
+
+- parseDateKey(dateKey)
+  "YYYY-MM-DD" を Date に戻します。
+
+- isDateKey(value)
+  文字列が正しい日付形式か確認します。
+
+- addDays(dateKey, delta)
+  dateKey に日数を足します。
+
+- getTodayDateKey()
+  今日の日付を dateKey で返します。
+
+dateKey を使う理由:
+
+- localStorage に保存しやすい
+- JSON にしやすい
+- 日付ごとの予定分類が簡単
+- Date オブジェクトのタイムゾーン問題を画面全体に広げにくい
+
+
+14. よくある読み方のコツ
+----------------------
+
+コードを読むときは、最初から細かい className を全部理解しようとしないでください。
+
+まず見るべきもの:
+
+- import
+  どの部品を使っているか
+
+- type
+  データの形
+
+- useState
+  何を状態として持っているか
+
+- useEffect
+  いつ副作用が起きるか
+
+- props
+  親から子へ何を渡しているか
+
+- callback
+  子から親へ何を知らせるか
+
+後回しでよいもの:
+
+- Tailwind の細かい見た目
+- SVG アイコンの path
+- shadow や border の細かい指定
+
+
+15. 変更するときの考え方
+----------------------
+
+Timebox に機能を追加するときは、次の順で考えると迷いにくいです。
+
+1. データの形を変える必要があるか
+   例: EventItem に color を追加するか。
+
+2. 保存形式を変える必要があるか
+   例: lib/storage.ts で color を読み込むか。
+
+3. 画面で入力する場所はどこか
+   例: EventDetailsPopover に色選択を足すか。
+
+4. 表示に反映する場所はどこか
+   例: EventBlock の背景色を変えるか。
+
+5. 既存データとの互換性はあるか
+   例: color がない古い予定でも壊れないか。
+
+
+16. 最小の理解チェック
+---------------------
+
+次のことを自分の言葉で説明できれば、Timebox の基本はつかめています。
+
+- EventItem の startMin と endMin が何を表すか
+- 予定ブロックの top と height がどう決まるか
+- items はどこで state として持たれているか
+- localStorage への保存はどの hook が担当しているか
+- WeekGrid、DayColumn、EventBlock の役割の違い
+- "use client" が必要な理由
+- JSON インポート時に lib/storage.ts が必要な理由
+
+
+17. 次に読むとよい順番
+--------------------
+
+1. docs/learning/timebox-practice-questions-ja.txt の問題を解く
+2. 問題で出てきたファイルを実際に開く
+3. 1つだけ小さな変更を試す
+4. npm run lint と npm run build で壊れていないか確認する
+
+最初の小さな変更例:
+
+- デフォルト予定時間を 30分から 45分に変える
+- 予定ブロックの最小高さを変える
+- 表示開始時刻の初期値を 6時から 7時に変える
+- JSON エクスポート時のファイル名を変える
+


### PR DESCRIPTION
## 概要
- ローカル開発ログの `dev-server.log` を ignore し、PR に混入しにくくする
- `docs/learning/` をリポジトリ管理対象の学習用ドキュメントとして整理する
- 学習用ドキュメントの README を追加する
- #43 の実装ログを追加し、issue log の索引から参照できるようにする
- 追加ドキュメントはできるだけ日本語中心の表記にする

Fixes #43.

## 検証
- npm run lint