### PR TITLE
Fix issue log README mojibake

### DIFF
--- a/docs/issue-logs/README.md
+++ b/docs/issue-logs/README.md
@@ -28,7 +28,7 @@ Each log should capture:
 - [Issue #34: Persist View Options](./issue-34-persist-view-options.md)
 - [Issue #36: Alarm Status and Test Controls](./issue-36-alarm-status-and-test-controls.md)
 - [Issue #38: Overlap Layout for Three or More Events](./issue-38-overlap-layout.md)
-- [Issue #43: ローカル生成物の扱い整理](./issue-43-local-artifacts.md)
+- [Issue #43: ローカル生成物の扱いを整理](./issue-43-local-artifacts.md)
 
 ## Japanese
 
@@ -39,3 +39,5 @@ Each log should capture:
 - 想定される原因
 - 採用した修正方針
 - 修正をどのように検証したか
+
+日本語のログや README は UTF-8 として保存します。


### PR DESCRIPTION
## Summary
- Fix the remaining mojibake wording in `docs/issue-logs/README.md`
- Keep the existing English and Logs sections while clarifying that Japanese docs should be saved as UTF-8

Closes #41

## Verification
- `npm run lint`
- `npm run build`