### PR TITLE
Add logic tests for time and storage

### DIFF
--- a/docs/issue-logs/README.md
+++ b/docs/issue-logs/README.md
@@ -24,6 +24,7 @@ Each log should capture:
 - [Issue #21: Inline Day Count Controls](./issue-21-inline-day-count-controls.md)
 - [Issue #23: Date Navigation Calendar Controls](./issue-23-date-navigation-calendar-controls.md)
 - [Issue #27: Mobile Swipe Navigation](./issue-27-mobile-swipe-navigation.md)
+- [Issue #32: Logic Layer Tests](./issue-32-logic-tests.md)
 - [Issue #33: Split Home Component Responsibilities](./issue-33-home-component-split.md)
 - [Issue #34: Persist View Options](./issue-34-persist-view-options.md)
 - [Issue #36: Alarm Status and Test Controls](./issue-36-alarm-status-and-test-controls.md)

--- a/docs/issue-logs/issue-32-logic-tests.md
+++ b/docs/issue-logs/issue-32-logic-tests.md
@@ -1,0 +1,21 @@
+# Issue #32: Logic Layer Tests
+
+## Symptom
+
+Core scheduling data could regress without a focused test catching it. Time formatting, minute snapping, event import validation, and legacy `dayIndex` migration all sit below the UI, so failures could surface as corrupted schedule data later.
+
+## Root cause
+
+The project already had build and lint coverage plus some date/alarm tests, but `lib/time.ts` and `lib/storage.ts` still lacked direct normal and error-path coverage.
+
+## Fix
+
+- Added tests for `pad2`, `minToHHMM`, `clamp`, and `snap`.
+- Added storage tests for `safeParse`, event validation, optional field normalization, JSON import rejection, and legacy `dayIndex` migration.
+- Added this issue log and restored the issue log README text so the test coverage change is discoverable.
+
+## Verification
+
+- `npm test`
+- `npm run lint`
+- `npm run build`

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -1,0 +1,146 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { getDateKeyForLegacyDayIndex } from "../lib/date"
+import { isValidEventItem, parseEventItems, safeParse, sanitizeEventItem } from "../lib/storage"
+
+test("safeParse returns parsed JSON or null", () => {
+    assert.deepEqual(safeParse<{ ok: boolean }>('{"ok":true}'), { ok: true })
+    assert.equal(safeParse("broken"), null)
+    assert.equal(safeParse(null), null)
+})
+
+test("isValidEventItem accepts bounded same-day events", () => {
+    assert.equal(
+        isValidEventItem({
+            id: "event-1",
+            dateKey: "2026-05-19",
+            startMin: 9 * 60,
+            endMin: 10 * 60,
+            label: "Focus",
+        }),
+        true
+    )
+})
+
+test("isValidEventItem rejects invalid dates and time ranges", () => {
+    const base = {
+        id: "event-1",
+        dateKey: "2026-05-19",
+        startMin: 9 * 60,
+        endMin: 10 * 60,
+    }
+
+    assert.equal(isValidEventItem({ ...base, id: "" }), false)
+    assert.equal(isValidEventItem({ ...base, dateKey: "2026-02-30" }), false)
+    assert.equal(isValidEventItem({ ...base, startMin: -1 }), false)
+    assert.equal(isValidEventItem({ ...base, startMin: 10 * 60, endMin: 9 * 60 }), false)
+    assert.equal(isValidEventItem({ ...base, endMin: 24 * 60 + 1 }), false)
+})
+
+test("sanitizeEventItem normalizes optional text and URL fields", () => {
+    assert.deepEqual(
+        sanitizeEventItem({
+            id: "event-1",
+            dateKey: "2026-05-19",
+            startMin: 9 * 60,
+            endMin: 10 * 60,
+            label: 123,
+            description: null,
+            urls: ["https://example.com", 42, "not validated here"],
+        }),
+        {
+            id: "event-1",
+            dateKey: "2026-05-19",
+            startMin: 9 * 60,
+            endMin: 10 * 60,
+            label: "",
+            description: "",
+            urls: ["https://example.com", "not validated here"],
+        }
+    )
+})
+
+test("sanitizeEventItem migrates legacy dayIndex records", () => {
+    assert.deepEqual(
+        sanitizeEventItem({
+            id: "legacy-1",
+            dayIndex: 2,
+            startMin: 8 * 60,
+            endMin: 9 * 60,
+            label: "Legacy",
+        }),
+        {
+            id: "legacy-1",
+            dateKey: getDateKeyForLegacyDayIndex(2),
+            startMin: 8 * 60,
+            endMin: 9 * 60,
+            label: "Legacy",
+            description: "",
+            urls: [],
+        }
+    )
+})
+
+test("parseEventItems accepts fully valid arrays", () => {
+    const raw = JSON.stringify([
+        {
+            id: "event-1",
+            dateKey: "2026-05-19",
+            startMin: 9 * 60,
+            endMin: 10 * 60,
+            label: "Focus",
+        },
+        {
+            id: "legacy-1",
+            dayIndex: 0,
+            startMin: 11 * 60,
+            endMin: 12 * 60,
+        },
+    ])
+
+    assert.deepEqual(parseEventItems(raw), [
+        {
+            id: "event-1",
+            dateKey: "2026-05-19",
+            startMin: 9 * 60,
+            endMin: 10 * 60,
+            label: "Focus",
+            description: "",
+            urls: [],
+        },
+        {
+            id: "legacy-1",
+            dateKey: getDateKeyForLegacyDayIndex(0),
+            startMin: 11 * 60,
+            endMin: 12 * 60,
+            label: "",
+            description: "",
+            urls: [],
+        },
+    ])
+})
+
+test("parseEventItems rejects invalid payloads and partially invalid arrays", () => {
+    assert.equal(parseEventItems(null), null)
+    assert.equal(parseEventItems("broken"), null)
+    assert.equal(parseEventItems("{}"), null)
+    assert.equal(
+        parseEventItems(
+            JSON.stringify([
+                {
+                    id: "event-1",
+                    dateKey: "2026-05-19",
+                    startMin: 9 * 60,
+                    endMin: 10 * 60,
+                },
+                {
+                    id: "bad",
+                    dateKey: "2026-05-19",
+                    startMin: 10 * 60,
+                    endMin: 9 * 60,
+                },
+            ])
+        ),
+        null
+    )
+})

--- a/tests/time.test.ts
+++ b/tests/time.test.ts
@@ -1,0 +1,29 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { clamp, minToHHMM, pad2, snap } from "../lib/time"
+
+test("pad2 formats single digit numbers", () => {
+    assert.equal(pad2(0), "00")
+    assert.equal(pad2(7), "07")
+    assert.equal(pad2(12), "12")
+})
+
+test("minToHHMM formats minutes and wraps outside one day", () => {
+    assert.equal(minToHHMM(0), "0:00")
+    assert.equal(minToHHMM(9 * 60 + 5), "9:05")
+    assert.equal(minToHHMM(24 * 60), "0:00")
+    assert.equal(minToHHMM(-15), "23:45")
+})
+
+test("clamp keeps values inside inclusive bounds", () => {
+    assert.equal(clamp(5, 0, 10), 5)
+    assert.equal(clamp(-1, 0, 10), 0)
+    assert.equal(clamp(11, 0, 10), 10)
+})
+
+test("snap rounds minutes to the nearest grid size", () => {
+    assert.equal(snap(7, 15), 0)
+    assert.equal(snap(8, 15), 15)
+    assert.equal(snap(37, 15), 30)
+    assert.equal(snap(38, 15), 45)
+})


### PR DESCRIPTION
## Summary
- Add focused tests for time formatting, clamping, and snapping utilities
- Add storage/import tests for JSON parsing, event validation, optional field normalization, invalid payload rejection, and legacy `dayIndex` migration
- Add an issue log for #32 and link it from the issue log README

Closes #32

## Verification
- `npm test`
- `npm run lint`
- `npm run build`